### PR TITLE
feat: 과제 마감일 및 비활성화 정책에 따른 문제 풀이 페이지 제어 구현

### DIFF
--- a/src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx
@@ -48,6 +48,9 @@ interface ProblemSolveViewProps {
 		gutterSize: number,
 		index: number,
 	) => Record<string, string>;
+	isDeadlinePassed: boolean;
+	isAssignmentActive: boolean;
+	userRole: string | null;
 }
 
 const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
@@ -79,6 +82,9 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 		handleHorizontalDragEnd,
 		handleVerticalDragEnd,
 		gutterStyleCallback,
+		isDeadlinePassed,
+		isAssignmentActive,
+		userRole,
 	} = props;
 	const navigate = useNavigate();
 
@@ -103,6 +109,9 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 				onSessionSave={saveToSession}
 				codeLoadSource={codeLoadSource}
 				sessionCleared={sessionCleared}
+				isDeadlinePassed={isDeadlinePassed}
+				isAssignmentActive={isAssignmentActive}
+				userRole={userRole}
 			/>
 		),
 		result: (

--- a/src/pages/AssignmentPage/ProblemSolvePage/index.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/index.tsx
@@ -49,6 +49,9 @@ const ProblemSolvePage: React.FC = () => {
 			handleHorizontalDragEnd={hook.handleHorizontalDragEnd}
 			handleVerticalDragEnd={hook.handleVerticalDragEnd}
 			gutterStyleCallback={hook.gutterStyleCallback}
+			isDeadlinePassed={hook.isDeadlinePassed}
+			isAssignmentActive={hook.isAssignmentActive}
+			userRole={hook.userRole}
 		/>
 	);
 };

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/CodeEditor/index.tsx
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/CodeEditor/index.tsx
@@ -30,6 +30,9 @@ interface CodeEditorProps {
 	onSessionSave?: () => void;
 	codeLoadSource?: string | null;
 	sessionCleared?: boolean;
+	isDeadlinePassed?: boolean;
+	isAssignmentActive?: boolean;
+	userRole?: string | null;
 }
 
 const CodeEditor: React.FC<CodeEditorProps> = ({
@@ -45,7 +48,18 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 	onSessionSave,
 	codeLoadSource = null,
 	sessionCleared = false,
+	isDeadlinePassed = false,
+	isAssignmentActive = true,
+	userRole = null,
 }) => {
+	// 관리자/튜터는 비활성화된 과제도 제출 가능
+	const isManager = userRole === "ADMIN" || userRole === "TUTOR";
+	const isSubmitDisabled = isSubmitting || isDeadlinePassed || (!isAssignmentActive && !isManager);
+	const disabledReason = isDeadlinePassed
+		? "과제 마감일이 지났습니다"
+		: !isAssignmentActive && !isManager
+			? "과제가 비활성화되었습니다"
+			: "";
 	const getBaseExtensions = () => [
 		bracketMatching(),
 		foldGutter(),
@@ -398,12 +412,19 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 					<S.SubmitButton
 						$variant="test"
 						onClick={onSubmitWithOutput}
-						disabled={isSubmitting}
-						title="테스트케이스별 상세 결과를 확인할 수 있습니다"
+						disabled={isSubmitDisabled}
+						title={
+							disabledReason ||
+							"테스트케이스별 상세 결과를 확인할 수 있습니다"
+						}
 					>
 						{isSubmitting ? "제출 중..." : "테스트하기"}
 					</S.SubmitButton>
-					<S.SubmitButton onClick={onSubmit} disabled={isSubmitting}>
+					<S.SubmitButton
+						onClick={onSubmit}
+						disabled={isSubmitDisabled}
+						title={disabledReason || "코드를 제출합니다"}
+					>
 						{isSubmitting ? "제출 중..." : "제출하기"}
 					</S.SubmitButton>
 				</S.EditorHeaderRight>


### PR DESCRIPTION


관련 이슈: #과제-마감일-비활성화-정책

## #️⃣연관된 이슈

#94 

## 📝작업 내용
과제의 마감일과 활성화 상태에 따라 문제 풀이 페이지의 제출/테스트 기능을 제어하는 로직을 추가했습니다.

주요 변경사항:
- useProblemSolve hook에 마감일/비활성화 체크 로직 추가
  - 페이지 로드 시 과제 정보 확인 및 상태 체크
  - 사용자 역할 확인 (getMyRoleInSection API 호출)
  - 학생인 경우 비활성화된 과제 접근 시 리다이렉트
- 제출/테스트 버튼 비활성화 로직 추가
  - 마감일 지남 또는 비활성화 시 버튼 비활성화
  - 관리자/튜터는 비활성화된 과제도 제출 가능
  - 버튼 툴팁에 비활성화 이유 표시
- 제출/테스트 시 사전 체크 및 에러 처리
  - 마감일/비활성화 에러 발생 시 알림 및 리다이렉트
  - 백엔드 에러 응답 파싱 및 처리
- CodeEditor 컴포넌트에 userRole prop 추가
  - 관리자/튜터 체크 로직 추가
  - 버튼 비활성화 조건 개선

UI/UX 개선:
- 비활성화된 과제 접근 시 course-assignments 페이지로 리다이렉트
- 에러 메시지 명확화
- 새로고침 시에도 상태 유지

### 스크린샷 (선택)


