### PR TITLE
feat/issue-100/Changelogoname,Userpagemodified

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>CodeSturdy</title>
+    <title>H-CodeLab</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,25 +1,25 @@
 {
-  "short_name": "CodeSturdy",
-  "name": "CodeSturdy - 한동대학교 온라인 저지",
-  "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
-    }
-  ],
-  "start_url": ".",
-  "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+	"short_name": "H-CodeLab",
+	"name": "H-CodeLab - 한동대학교 온라인 저지",
+	"icons": [
+		{
+			"src": "favicon.ico",
+			"sizes": "64x64 32x32 24x24 16x16",
+			"type": "image/x-icon"
+		},
+		{
+			"src": "logo192.png",
+			"type": "image/png",
+			"sizes": "192x192"
+		},
+		{
+			"src": "logo512.png",
+			"type": "image/png",
+			"sizes": "512x512"
+		}
+	],
+	"start_url": ".",
+	"display": "standalone",
+	"theme_color": "#000000",
+	"background_color": "#ffffff"
 }

--- a/src/components/Course/CourseSidebar/index.tsx
+++ b/src/components/Course/CourseSidebar/index.tsx
@@ -212,8 +212,8 @@ const CourseSidebar: React.FC<CourseSidebarProps> = ({
 				className={isCollapsed ? "collapsed" : ""}
 			>
 				<S.SidebarHeader onClick={() => !isCollapsed && navigate("/index")}>
-					<S.SidebarLogo src="/logo.svg" alt="CodeSturdy Logo" />
-					{!isCollapsed && <S.SidebarTitle>CodeSturdy</S.SidebarTitle>}
+					<S.SidebarLogo src="/logo.svg" alt="H-CodeLab Logo" />
+					{!isCollapsed && <S.SidebarTitle>H-CodeLab</S.SidebarTitle>}
 				</S.SidebarHeader>
 
 				<S.SidebarMenu>

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -36,9 +36,9 @@ const Header: React.FC<HeaderProps> = ({ onUserNameClick }) => {
 			<S.HeaderWrapper>
 				<S.Logo onClick={handleLogoClick}>
 					<S.LogoIcon>
-						<img src="/logo.svg" alt="CodeSturdy Logo" />
+						<img src="/logo.svg" alt="H-CodeLab Logo" />
 					</S.LogoIcon>
-					<S.LogoText>CodeSturdy</S.LogoText>
+					<S.LogoText>H-CodeLab</S.LogoText>
 				</S.Logo>
 				<S.HeaderLinks>
 					{isAuthenticated ? (

--- a/src/components/Layout/Navbar/index.tsx
+++ b/src/components/Layout/Navbar/index.tsx
@@ -51,9 +51,9 @@ const Navbar: React.FC = () => {
 					<S.LogoLink to="/index">
 						<S.LogoImage
 							src={`${process.env.PUBLIC_URL || ""}/logo.svg`}
-							alt="CodeSturdy"
+							alt="H-CodeLab"
 						/>
-						<span>CodeSturdy</span>
+						<span>H-CodeLab</span>
 					</S.LogoLink>
 					<S.NavLink to="/index">강의</S.NavLink>
 					{!checking && hasManagingSections && (

--- a/src/components/Tutor/TutorHeader/index.tsx
+++ b/src/components/Tutor/TutorHeader/index.tsx
@@ -65,9 +65,9 @@ const TutorHeader: React.FC = () => {
 					<S.LogoLink to="/tutor">
 						<S.LogoImage
 							src={`${process.env.PUBLIC_URL || ""}/logo.svg`}
-							alt="CodeSturdy"
+							alt="H-CodeLab"
 						/>
-						<span>CodeSturdy</span>
+						<span>H-CodeLab</span>
 					</S.LogoLink>
 				</S.Left>
 

--- a/src/layouts/TutorLayout/index.tsx
+++ b/src/layouts/TutorLayout/index.tsx
@@ -386,18 +386,18 @@ const TutorLayout: React.FC<TutorLayoutProps> = ({
 				icon: FaChartBar,
 				subItems: [],
 			},
-			{
-				path: `/tutor/notifications/section/${currentSection.sectionId}`,
-				label: "수업 알림",
-				icon: FaBell,
-				subItems: [],
-			},
-			{
-				path: `/tutor/stats/section/${currentSection.sectionId}`,
-				label: "수업 통계",
-				icon: FaChartBar,
-				subItems: [],
-			},
+			// {
+			// 	path: `/tutor/notifications/section/${currentSection.sectionId}`,
+			// 	label: "수업 알림",
+			// 	icon: FaBell,
+			// 	subItems: [],
+			// },
+			// {
+			// 	path: `/tutor/stats/section/${currentSection.sectionId}`,
+			// 	label: "수업 통계",
+			// 	icon: FaChartBar,
+			// 	subItems: [],
+			// },
 		];
 
 		return baseMenus;

--- a/src/pages/Auth/IndexPage/components/IndexPageView.tsx
+++ b/src/pages/Auth/IndexPage/components/IndexPageView.tsx
@@ -23,7 +23,7 @@ export default function IndexPageView(d: IndexPageHookReturn) {
 				<S.HeroSection>
 					<S.HeroContentWrapper>
 						<S.HeroContent>
-							<S.HeroTitle>Code Sturdy</S.HeroTitle>
+							<S.HeroTitle>H-CodeLab</S.HeroTitle>
 							<S.HeroDescription>
 								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sit
 								amet risus nisi, integer firibus faucibus pours. Maecenas

--- a/src/pages/Auth/LoginPage/components/LoginPageView.tsx
+++ b/src/pages/Auth/LoginPage/components/LoginPageView.tsx
@@ -17,9 +17,9 @@ export default function LoginPageView(d: LoginPageHookReturn) {
 				<S.Logo>
 					<S.LogoImage
 						src={`${process.env.PUBLIC_URL || ""}/logo.svg`}
-						alt="CodeSturdy"
+						alt="H-CodeLab"
 					/>
-					<span>CodeSturdy</span>
+					<span>H-CodeLab</span>
 				</S.Logo>
 				<S.EnterpriseLink>기업서비스</S.EnterpriseLink>
 			</S.Header>
@@ -27,7 +27,7 @@ export default function LoginPageView(d: LoginPageHookReturn) {
 			<S.MainContent>
 				<S.LeftSection>
 					<S.WelcomeText>
-						반가워요, 개발자의 성장을 돕는 CodeSturdy입니다.
+						반가워요, 개발자의 성장을 돕는 H-CodeLab입니다.
 					</S.WelcomeText>
 					<S.Illustrations>
 						<S.IllustrationItem>
@@ -50,7 +50,7 @@ export default function LoginPageView(d: LoginPageHookReturn) {
 
 				<S.RightSection>
 					<S.LoginCard>
-						<S.LoginTitle>CodeSturdy 로그인</S.LoginTitle>
+						<S.LoginTitle>H-CodeLab 로그인</S.LoginTitle>
 						{(d.loginMessage || d.pendingEnrollmentCode) && (
 							<S.LoginMessage>
 								{d.loginMessage || "수업 참가를 위해 로그인이 필요합니다."}

--- a/src/pages/TutorPage/Dashboard/components/CopySectionModal.tsx
+++ b/src/pages/TutorPage/Dashboard/components/CopySectionModal.tsx
@@ -126,7 +126,7 @@ const CopySectionModal: React.FC<CopySectionModalProps> = (props) => {
 				onClick={(e) => e.stopPropagation()}
 			>
 				<S.ModalHeader>
-					<h2>기존 수업 복사</h2>
+					<h2 style={{ color: "white" }}>기존 수업 복사</h2>
 					<S.ModalClose onClick={onClose}>×</S.ModalClose>
 				</S.ModalHeader>
 				<S.ModalBody $large={copyStep > 1}>

--- a/src/pages/TutorPage/Dashboard/components/CreateSectionModal.tsx
+++ b/src/pages/TutorPage/Dashboard/components/CreateSectionModal.tsx
@@ -25,7 +25,7 @@ const CreateSectionModal: React.FC<CreateSectionModalProps> = ({
 		<S.ModalOverlay onClick={onClose}>
 			<S.ModalContent onClick={(e) => e.stopPropagation()}>
 				<S.ModalHeader>
-					<h2>새 수업 만들기</h2>
+					<h2 style={{ color: "white" }}>새 수업 만들기</h2>
 					<S.ModalClose onClick={onClose}>×</S.ModalClose>
 				</S.ModalHeader>
 				<S.ModalBody>
@@ -57,7 +57,10 @@ const CreateSectionModal: React.FC<CreateSectionModalProps> = ({
 									type="text"
 									value={formData.courseTitle}
 									onChange={(e) =>
-										setFormData((prev) => ({ ...prev, courseTitle: e.target.value }))
+										setFormData((prev) => ({
+											...prev,
+											courseTitle: e.target.value,
+										}))
 									}
 									placeholder="예: 자바프로그래밍"
 								/>
@@ -67,7 +70,10 @@ const CreateSectionModal: React.FC<CreateSectionModalProps> = ({
 								<S.FormTextarea
 									value={formData.description}
 									onChange={(e) =>
-										setFormData((prev) => ({ ...prev, description: e.target.value }))
+										setFormData((prev) => ({
+											...prev,
+											description: e.target.value,
+										}))
 									}
 									placeholder="수업에 대한 설명을 입력하세요 (선택사항)"
 									rows={3}

--- a/src/pages/TutorPage/Dashboard/styles.ts
+++ b/src/pages/TutorPage/Dashboard/styles.ts
@@ -549,7 +549,8 @@ export const ModalHeader = styled.div`
   align-items: center;
   padding: 1.75rem 2rem;
   border-bottom: 1px solid #e5e7eb;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: #667eea;
+  /* linear-gradient(135deg, #667eea 0%, #764ba2 100%); */
   color: white;
 
   h2 {

--- a/src/pages/TutorPage/Problems/ProblemSetManagement/components/ProblemSetManagementView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemSetManagement/components/ProblemSetManagementView.tsx
@@ -108,7 +108,7 @@ export default function ProblemSetManagementView(
 					<S.ModalOverlay onClick={() => !d.isCreating && d.closeCreateModal()}>
 						<S.ModalContent onClick={(e) => e.stopPropagation()}>
 							<S.ModalHeader>
-								<h2>새 문제집 만들기</h2>
+								<h2 style={{ color: "white" }}>새 문제집 만들기</h2>
 								<S.ModalClose
 									type="button"
 									onClick={() => !d.isCreating && d.closeCreateModal()}

--- a/src/pages/TutorPage/Problems/ProblemSetManagement/styles.ts
+++ b/src/pages/TutorPage/Problems/ProblemSetManagement/styles.ts
@@ -308,7 +308,7 @@ export const ModalHeader = styled.div`
 	align-items: center;
 	padding: 1.75rem 2rem;
 	border-bottom: 1px solid #e5e7eb;
-	background: #f9fafb;
+	background: #667eea;
 	color: #1e293b;
 
 	h2 {

--- a/src/pages/TutorPage/Users/UserManagement/components/UserManagementFilters.tsx
+++ b/src/pages/TutorPage/Users/UserManagement/components/UserManagementFilters.tsx
@@ -7,6 +7,8 @@ interface UserManagementFiltersProps {
 	onSearchChange: (value: string) => void;
 	filterRole: RoleFilter;
 	onFilterRoleChange: (value: RoleFilter) => void;
+	/** 현재 로그인한 사용자의 이 수업 내 역할 (관리자/튜터일 때만 표시) */
+	currentUserRole: string | null;
 }
 
 const UserManagementFilters: React.FC<UserManagementFiltersProps> = ({
@@ -14,13 +16,14 @@ const UserManagementFilters: React.FC<UserManagementFiltersProps> = ({
 	onSearchChange,
 	filterRole,
 	onFilterRoleChange,
+	currentUserRole,
 }) => (
 	<S.Container>
 		<S.Filters>
 			<S.SearchBox>
 				<S.SearchInput
 					type="text"
-					placeholder="이름, 이메일, 팀ID로 검색..."
+					placeholder="이름, 이메일로 검색..."
 					value={searchTerm}
 					onChange={(e) => onSearchChange(e.target.value)}
 				/>
@@ -34,6 +37,12 @@ const UserManagementFilters: React.FC<UserManagementFiltersProps> = ({
 				<option value="TUTOR">튜터</option>
 				<option value="ADMIN">관리자</option>
 			</S.Select>
+			{currentUserRole === "ADMIN" && (
+				<S.CurrentRoleBadge $role="ADMIN">현재 권한: 관리자</S.CurrentRoleBadge>
+			)}
+			{currentUserRole === "TUTOR" && (
+				<S.CurrentRoleBadge $role="TUTOR">현재 권한: 튜터</S.CurrentRoleBadge>
+			)}
 		</S.Filters>
 	</S.Container>
 );

--- a/src/pages/TutorPage/Users/UserManagement/components/UserManagementHeader.tsx
+++ b/src/pages/TutorPage/Users/UserManagement/components/UserManagementHeader.tsx
@@ -23,7 +23,7 @@ const UserManagementHeader: React.FC<UserManagementHeaderProps> = ({
 				<S.SearchBox>
 					<S.SearchInput
 						type="text"
-						placeholder="이름, 이메일, 팀ID로 검색..."
+						placeholder="이름, 이메일로 검색..."
 						value={searchTerm}
 						onChange={(e) => onSearchChange(e.target.value)}
 					/>

--- a/src/pages/TutorPage/Users/UserManagement/components/UserManagementTable.tsx
+++ b/src/pages/TutorPage/Users/UserManagement/components/UserManagementTable.tsx
@@ -18,7 +18,6 @@ interface UserManagementTableProps {
 	onSort: (field: SortField) => void;
 	onPageChange: (page: number) => void;
 	onItemsPerPageChange: (n: number) => void;
-	onStudentDetail: (student: Student) => void;
 	onAddTutor: (userId: number) => void;
 	onRemoveTutor: (userId: number) => void;
 	getSortIcon: (field: SortField) => React.ReactNode;
@@ -39,7 +38,6 @@ const UserManagementTable: React.FC<UserManagementTableProps> = ({
 	onSort,
 	onPageChange,
 	onItemsPerPageChange,
-	onStudentDetail,
 	onAddTutor,
 	onRemoveTutor,
 	getSortIcon,
@@ -56,6 +54,7 @@ const UserManagementTable: React.FC<UserManagementTableProps> = ({
 									{getSortIcon("name")}
 								</S.ThContent>
 							</S.Th>
+							<S.Th>학번</S.Th>
 							<S.Th className="sortable" onClick={() => onSort("email")}>
 								<S.ThContent>
 									이메일
@@ -65,19 +64,14 @@ const UserManagementTable: React.FC<UserManagementTableProps> = ({
 							{!sectionId && <S.Th>과목</S.Th>}
 							{!sectionId && <S.Th>분반</S.Th>}
 							{sectionId && <S.Th>역할</S.Th>}
-							<S.Th className="sortable" onClick={() => onSort("progress")}>
-								<S.ThContent>
-									전체 과제 진도율
-									{getSortIcon("progress")}
-								</S.ThContent>
-							</S.Th>
 							<S.Th style={{ textAlign: "right" }}>작업</S.Th>
 						</tr>
 					</thead>
 					<tbody>
 						{paginatedStudents.map((student) => {
+							// API에서 내려준 role 우선, 없으면 기존 userRoles 사용
 							const userRole = sectionId
-								? userRoles[student.userId] || "STUDENT"
+								? (student.role ?? userRoles[student.userId] ?? "STUDENT")
 								: null;
 							const isAdmin = currentUserRole === "ADMIN";
 							const isTutor = userRole === "TUTOR";
@@ -86,6 +80,7 @@ const UserManagementTable: React.FC<UserManagementTableProps> = ({
 							return (
 								<tr key={student.userId}>
 									<S.NameCell>{student.name}</S.NameCell>
+									<S.Td>{student.studentId ?? "-"}</S.Td>
 									<S.EmailCell>{student.email}</S.EmailCell>
 									{!sectionId && (
 										<S.CourseCell>{student.courseTitle}</S.CourseCell>
@@ -121,30 +116,8 @@ const UserManagementTable: React.FC<UserManagementTableProps> = ({
 											</S.Badge>
 										</S.Td>
 									)}
-									<S.ProgressCell>
-										<S.ProgressInfo>
-											<S.ProgressBarContainer>
-												<S.ProgressBarFill
-													style={{
-														width: `${student.assignmentCompletionRate || 0}%`,
-													}}
-												/>
-											</S.ProgressBarContainer>
-											<S.ProgressText>
-												{student.assignmentCompletionRate
-													? `${student.assignmentCompletionRate.toFixed(1)}%`
-													: "0%"}
-											</S.ProgressText>
-										</S.ProgressInfo>
-									</S.ProgressCell>
 									<S.ActionsCellTd>
 										<S.ActionsCell>
-											<S.ActionButton
-												onClick={() => onStudentDetail(student)}
-												title="상세 보기"
-											>
-												상세 보기
-											</S.ActionButton>
 											{sectionId && isAdmin && (
 												<>
 													{isStudent && (

--- a/src/pages/TutorPage/Users/UserManagement/hooks/useUserManagement.ts
+++ b/src/pages/TutorPage/Users/UserManagement/hooks/useUserManagement.ts
@@ -4,8 +4,6 @@ import APIService from "../../../../../services/APIService";
 import type {
 	Student,
 	SectionInfo,
-	Assignment,
-	ProblemStatus,
 	SortField,
 	SortDirection,
 	RoleFilter,
@@ -30,17 +28,6 @@ export function useUserManagement() {
 	const [currentUserRole, setCurrentUserRole] = useState<string | null>(null);
 	const [sortField, setSortField] = useState<SortField>("name");
 	const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
-	const [showDetailModal, setShowDetailModal] = useState(false);
-	const [selectedStudent, setSelectedStudent] = useState<Student | null>(null);
-	const [studentAssignments, setStudentAssignments] = useState<Assignment[]>(
-		[],
-	);
-	const [expandedAssignment, setExpandedAssignment] = useState<number | null>(
-		null,
-	);
-	const [assignmentProblemsDetail, setAssignmentProblemsDetail] = useState<
-		Record<number, ProblemStatus[]>
-	>({});
 
 	const fetchUserRoles = useCallback(
 		async (sid: number, studentsData: Student[]) => {
@@ -159,61 +146,6 @@ export function useUserManagement() {
 		[sectionId, fetchStudents],
 	);
 
-	const handleStudentDetailView = useCallback(async (student: Student) => {
-		setSelectedStudent(student);
-		setShowDetailModal(true);
-		try {
-			const response = await APIService.getStudentAssignmentsProgress(
-				student.userId,
-				student.sectionId,
-			);
-			const progressData = response?.data || response;
-			setStudentAssignments(progressData || []);
-		} catch (error) {
-			console.error("학생 과제 정보 조회 실패:", error);
-			setStudentAssignments([]);
-		}
-	}, []);
-
-	const handleToggleAssignmentDetail = useCallback(
-		async (assignmentId: number) => {
-			if (expandedAssignment === assignmentId) {
-				setExpandedAssignment(null);
-				return;
-			}
-			setExpandedAssignment(assignmentId);
-			if (assignmentProblemsDetail[assignmentId]) return;
-			if (!selectedStudent) return;
-			try {
-				const response = await APIService.getStudentAssignmentProblemsStatus(
-					selectedStudent.userId,
-					selectedStudent.sectionId,
-					assignmentId,
-				);
-				const problemsData = response?.data || response;
-				setAssignmentProblemsDetail((prev) => ({
-					...prev,
-					[assignmentId]: problemsData || [],
-				}));
-			} catch (error) {
-				console.error("과제 문제 상태 조회 실패:", error);
-				setAssignmentProblemsDetail((prev) => ({
-					...prev,
-					[assignmentId]: [],
-				}));
-			}
-		},
-		[expandedAssignment, assignmentProblemsDetail, selectedStudent],
-	);
-
-	const handleCloseDetailModal = useCallback(() => {
-		setShowDetailModal(false);
-		setSelectedStudent(null);
-		setStudentAssignments([]);
-		setExpandedAssignment(null);
-		setAssignmentProblemsDetail({});
-	}, []);
-
 	const filteredStudents = students.filter((student) => {
 		const matchesSearch =
 			student.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -265,10 +197,6 @@ export function useUserManagement() {
 			case "email":
 				aValue = a.email || "";
 				bValue = b.email || "";
-				break;
-			case "progress":
-				aValue = a.assignmentCompletionRate ?? 0;
-				bValue = b.assignmentCompletionRate ?? 0;
 				break;
 			case "joinedAt":
 				aValue = a.joinedAt ? new Date(a.joinedAt).getTime() : 0;
@@ -328,11 +256,6 @@ export function useUserManagement() {
 		currentUserRole,
 		sortField,
 		sortDirection,
-		showDetailModal,
-		selectedStudent,
-		studentAssignments,
-		expandedAssignment,
-		assignmentProblemsDetail,
 		paginatedStudents,
 		sortedStudents,
 		totalPages,
@@ -340,9 +263,6 @@ export function useUserManagement() {
 		getSectionDisplayName,
 		fetchStudents,
 		handleSort,
-		handleStudentDetailView,
-		handleToggleAssignmentDetail,
-		handleCloseDetailModal,
 		handleAddTutor,
 		handleRemoveTutor,
 	};

--- a/src/pages/TutorPage/Users/UserManagement/index.tsx
+++ b/src/pages/TutorPage/Users/UserManagement/index.tsx
@@ -5,7 +5,6 @@ import { useUserManagement } from "./hooks/useUserManagement";
 import UserManagementHeader from "./components/UserManagementHeader";
 import UserManagementFilters from "./components/UserManagementFilters";
 import UserManagementTable from "./components/UserManagementTable";
-import StudentDetailModal from "./components/StudentDetailModal";
 import * as S from "./styles";
 import type { SortField } from "./types";
 
@@ -30,23 +29,15 @@ const UserManagement: FC = () => {
 		currentUserRole,
 		sortField,
 		sortDirection,
-		studentAssignments,
-		expandedAssignment,
-		assignmentProblemsDetail,
 		paginatedStudents,
 		totalPages,
 		uniqueSections,
 		getSectionDisplayName,
 		handleSort,
-		handleStudentDetailView,
-		handleToggleAssignmentDetail,
-		handleCloseDetailModal,
 		handleAddTutor,
 		handleRemoveTutor,
 	} = data;
 	const sortedStudents = data.sortedStudents;
-	const showDetailModal = data.showDetailModal;
-	const selectedStudent = data.selectedStudent;
 
 	const getSortIcon = (field: SortField) => {
 		if (sortField !== field) {
@@ -98,6 +89,7 @@ const UserManagement: FC = () => {
 					onSearchChange={setSearchTerm}
 					filterRole={filterRole}
 					onFilterRoleChange={setFilterRole}
+					currentUserRole={currentUserRole}
 				/>
 			)}
 			<UserManagementTable
@@ -115,18 +107,9 @@ const UserManagement: FC = () => {
 				onSort={handleSort}
 				onPageChange={setCurrentPage}
 				onItemsPerPageChange={setItemsPerPage}
-				onStudentDetail={handleStudentDetailView}
 				onAddTutor={handleAddTutor}
 				onRemoveTutor={handleRemoveTutor}
 				getSortIcon={getSortIcon}
-			/>
-			<StudentDetailModal
-				open={showDetailModal && selectedStudent !== null}
-				onClose={handleCloseDetailModal}
-				studentAssignments={studentAssignments}
-				expandedAssignment={expandedAssignment}
-				assignmentProblemsDetail={assignmentProblemsDetail}
-				onToggleAssignmentDetail={handleToggleAssignmentDetail}
 			/>
 		</TutorLayout>
 	);

--- a/src/pages/TutorPage/Users/UserManagement/styles.ts
+++ b/src/pages/TutorPage/Users/UserManagement/styles.ts
@@ -82,12 +82,24 @@ export const SearchInput = styled.input`
 /* 모달 열림 시 search input focus 스타일 무시 */
 export const Filters = styled.div`
   display: flex;
+  align-items: center;
   gap: 1rem;
   margin-bottom: 1.5rem;
   padding: 1rem;
   background: white;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+`;
+
+export const CurrentRoleBadge = styled.span<{ $role: "ADMIN" | "TUTOR" }>`
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.75rem;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: white;
+  background: ${(p) => (p.$role === "ADMIN" ? "#e17055" : "#667eea")};
 `;
 
 export const Select = styled.select<{ $inHeader?: boolean }>`

--- a/src/pages/TutorPage/Users/UserManagement/types.ts
+++ b/src/pages/TutorPage/Users/UserManagement/types.ts
@@ -2,6 +2,8 @@ export interface Student {
 	userId: number;
 	name: string;
 	email: string;
+	/** 학번 (회원가입 시 입력, API: studentId) */
+	studentId?: string;
 	teamId?: string;
 	sectionId: number;
 	sectionName?: string;
@@ -38,6 +40,6 @@ export interface ProblemStatus {
 	submissionCount: number;
 }
 
-export type SortField = "name" | "email" | "progress" | "joinedAt";
+export type SortField = "name" | "email" | "joinedAt";
 export type SortDirection = "asc" | "desc";
 export type RoleFilter = "ALL" | "STUDENT" | "TUTOR" | "ADMIN";

--- a/src/utils/IndexedDBManager.ts
+++ b/src/utils/IndexedDBManager.ts
@@ -19,7 +19,7 @@ interface IDBOpenDBRequestEvent extends Event {
 }
 
 class IndexedDBManager {
-	private dbName = "CodeSturdyDB";
+	private dbName = "H-CodeLabDB";
 	private dbVersion = 1;
 	private storeName = "codeStorage";
 	private db: IDBDatabase | null = null;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #100 

### 수정 요약
- 수강생 관리 페이지 UI 단순화 및 역할 표시/튜터 버튼 로직 개선

### 변경 파일 및 내용

| 파일 | 변경 내용 |
|------|-----------|
| `UserManagementTable.tsx` | **제거:** "전체 과제 진도율" 컬럼, "상세 보기" 버튼, `onStudentDetail` prop · **추가:** 학번 컬럼(헤더 + `student.studentId` 셀) · **역할 표시:** API 응답의 `student.role`을 우선 사용하고, 없을 때만 `userRoles[student.userId]` 사용 (`student.role ?? userRoles[student.userId] ?? "STUDENT"`) |
| `UserManagementFilters.tsx` | **추가:** `currentUserRole` prop 및 "현재 권한: 관리자" / "현재 권한: 튜터" 배지 표시 · 검색 placeholder를 "이름, 이메일로 검색..."으로 변경 |
| `UserManagement/index.tsx` | **제거:** `StudentDetailModal` import/렌더 및 상세 보기 관련 state·핸들러 전달 · **추가:** 분반 선택 시 `UserManagementFilters`에 `currentUserRole` 전달 |
| `useUserManagement.ts` | **제거:** 상세 보기 모달 관련 state·핸들러 (`studentAssignments`, `expandedAssignment`, `assignmentProblemsDetail`, `showDetailModal`, `selectedStudent`, `handleStudentDetailView`, `handleToggleAssignmentDetail`, `handleCloseDetailModal`) |
| `types.ts` | **추가:** `Student`에 `studentId?: string`, `role?: string` · **변경:** `SortField`에서 `"progress"` 제거 → `"name" \| "email" \| "joinedAt"` |
| `styles.ts` | **추가:** `CurrentRoleBadge` 스타일 컴포넌트 (역할 배지용) |

### 동작 변경 요약
- **전체 과제 진도율** 컬럼 제거
- **상세 보기** 버튼 및 모달 제거
- **학번** 컬럼 추가 (API `studentId` 표시)
- **현재 권한** 표시: 분반 선택 시 "현재 권한: 관리자" 또는 "현재 권한: 튜터" 배지 표시
- **튜터 추가/제거 버튼:** 백엔드에서 내려주는 `student.role`을 우선 사용해, 튜터 추가 후 목록 갱신 시에도 이미 튜터인 사용자에게는 "튜터 추가"가 보이지 않도록 수정
