### PR TITLE
1.성적 관리수정

### DIFF
--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementAssignmentTable.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementAssignmentTable.tsx
@@ -1,12 +1,5 @@
 import type React from "react";
-import {
-	FaEdit,
-	FaCode,
-	FaCheckCircle,
-	FaTimesCircle,
-	FaClock,
-	FaCalendarAlt,
-} from "react-icons/fa";
+import { FaCode, FaCheckCircle, FaTimesCircle } from "react-icons/fa";
 import * as S from "../styles";
 import type { StudentGradeRow, EditingGrade, AssignmentItem } from "../types";
 
@@ -53,7 +46,7 @@ export default function GradeManagementAssignmentTable({
 
 	return (
 		<S.CourseTableContainer>
-			<S.CourseTable>
+			<S.CourseTableWithStickyRight>
 				<colgroup>
 					<col style={{ width: S.STICKY_COL_1_WIDTH }} />
 					<col style={{ width: S.STICKY_COL_2_WIDTH }} />
@@ -63,6 +56,8 @@ export default function GradeManagementAssignmentTable({
 							))
 						: [<col key="no-problem" style={{ width: S.COL_PROBLEM_WIDTH }} />]}
 					<col style={{ width: S.COL_SCORE_WIDTH }} />
+					<col style={{ width: S.STICKY_RIGHT_TOTAL_WIDTH }} />
+					<col style={{ width: S.STICKY_RIGHT_RATIO_WIDTH }} />
 				</colgroup>
 				<thead>
 					{hasProblems ? (
@@ -77,13 +72,10 @@ export default function GradeManagementAssignmentTable({
 									<S.ItemTitle>
 										{selectedAssignment?.title ?? "과제"}
 									</S.ItemTitle>
-									{assignmentDue && (
-										<S.ItemDue>
-											마감: {new Date(assignmentDue).toLocaleString("ko-KR")}
-										</S.ItemDue>
-									)}
 								</S.CourseAssignmentHeader>
 								<th rowSpan={2}>총점</th>
+								<th rowSpan={2}>전체 총점</th>
+								<th rowSpan={2}>비율</th>
 							</tr>
 							<tr>
 								{grades[0]?.problemGrades?.map((p) => (
@@ -100,13 +92,10 @@ export default function GradeManagementAssignmentTable({
 							<th>학번</th>
 							<S.CourseAssignmentHeader as="th">
 								<S.ItemTitle>과제</S.ItemTitle>
-								{assignmentDue && (
-									<S.ItemDue>
-										마감: {new Date(assignmentDue).toLocaleString("ko-KR")}
-									</S.ItemDue>
-								)}
 							</S.CourseAssignmentHeader>
 							<th>총점</th>
+							<th>전체 총점</th>
+							<th>비율</th>
 						</tr>
 					)}
 				</thead>
@@ -183,11 +172,8 @@ export default function GradeManagementAssignmentTable({
 													</S.EditForm>
 												) : (
 													<S.ScoreDisplay>
-														<S.ScoreValue>
-															{`${problem.score ?? 0} / ${problem.points ?? 0}`}
-														</S.ScoreValue>
-														<S.ScoreActions>
-															<button
+														<S.ScoreRow>
+															<S.ScoreValueButton
 																type="button"
 																onClick={() => {
 																	setEditingGrade({
@@ -205,8 +191,8 @@ export default function GradeManagementAssignmentTable({
 																}}
 																title="점수 입력/수정"
 															>
-																<FaEdit />
-															</button>
+																{`${problem.score ?? 0} / ${problem.points ?? 0}`}
+															</S.ScoreValueButton>
 															{problem.submitted && (
 																<button
 																	type="button"
@@ -221,49 +207,29 @@ export default function GradeManagementAssignmentTable({
 																	<FaCode />
 																</button>
 															)}
-														</S.ScoreActions>
-														{(problem.submitted ||
-															selectedAssignment?.dueDate ||
-															selectedAssignment?.endDate ||
-															selectedAssignment?.deadline) && (
-															<S.SubmissionInfo>
-																{problem.submitted && (
+															{(problem.submitted ||
+																(assignmentDue &&
+																	new Date() > new Date(assignmentDue))) &&
+																(problem.submitted ? (
 																	<S.SubmissionStatus
 																		$onTime={problem.isOnTime}
 																	>
 																		{problem.isOnTime ? (
 																			<>
-																				<FaCheckCircle /> 정시 제출
+																				<FaCheckCircle />
 																			</>
 																		) : (
 																			<>
-																				<FaTimesCircle /> 기한 초과
+																				<FaTimesCircle />
 																			</>
 																		)}
 																	</S.SubmissionStatus>
-																)}
-																{(() => {
-																	const dueAt =
-																		selectedAssignment?.dueDate ??
-																		selectedAssignment?.endDate ??
-																		selectedAssignment?.deadline;
-																	return dueAt ? (
-																		<S.SubmissionDue>
-																			<FaCalendarAlt /> 제출 기한:{" "}
-																			{new Date(dueAt).toLocaleString("ko-KR")}
-																		</S.SubmissionDue>
-																	) : null;
-																})()}
-																{problem.submittedAt && (
-																	<S.SubmissionTime>
-																		<FaClock /> 제출 시간:{" "}
-																		{new Date(
-																			problem.submittedAt,
-																		).toLocaleString("ko-KR")}
-																	</S.SubmissionTime>
-																)}
-															</S.SubmissionInfo>
-														)}
+																) : (
+																	<S.SubmissionStatus $onTime={false}>
+																		<FaTimesCircle />
+																	</S.SubmissionStatus>
+																))}
+														</S.ScoreRow>
 													</S.ScoreDisplay>
 												)}
 											</S.TdCourseProblemCell>
@@ -279,11 +245,21 @@ export default function GradeManagementAssignmentTable({
 										{totalScore} / {totalPoints}
 									</strong>
 								</S.TdCourseAssignmentTotalCell>
+								<td>
+									<strong>
+										{totalScore} / {totalPoints}
+									</strong>
+								</td>
+								<td>
+									{totalPoints > 0
+										? `${((totalScore / totalPoints) * 100).toFixed(1)}%`
+										: "-"}
+								</td>
 							</tr>
 						);
 					})}
 				</tbody>
-			</S.CourseTable>
+			</S.CourseTableWithStickyRight>
 		</S.CourseTableContainer>
 	);
 }

--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementQuizTable.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementQuizTable.tsx
@@ -1,12 +1,5 @@
 import type React from "react";
-import {
-	FaEdit,
-	FaCode,
-	FaCheckCircle,
-	FaTimesCircle,
-	FaClock,
-	FaCalendarAlt,
-} from "react-icons/fa";
+import { FaCode, FaCheckCircle, FaTimesCircle } from "react-icons/fa";
 import * as S from "../styles";
 import type { StudentGradeRow, QuizItem, EditingGrade } from "../types";
 
@@ -58,7 +51,7 @@ export default function GradeManagementQuizTable({
 
 	return (
 		<S.CourseTableContainer>
-			<S.CourseTable>
+			<S.CourseTableWithStickyRight>
 				<colgroup>
 					<col style={{ width: S.STICKY_COL_1_WIDTH }} />
 					<col style={{ width: S.STICKY_COL_2_WIDTH }} />
@@ -66,6 +59,8 @@ export default function GradeManagementQuizTable({
 						<col key={p.problemId} style={{ width: S.COL_PROBLEM_WIDTH }} />
 					))}
 					<col style={{ width: S.COL_SCORE_WIDTH }} />
+					<col style={{ width: S.STICKY_RIGHT_TOTAL_WIDTH }} />
+					<col style={{ width: S.STICKY_RIGHT_RATIO_WIDTH }} />
 				</colgroup>
 				<thead>
 					<tr>
@@ -77,14 +72,10 @@ export default function GradeManagementQuizTable({
 									<S.ItemTypeBadge>퀴즈</S.ItemTypeBadge>
 									{quizTitle}
 								</S.ItemTitle>
-								{selectedQuiz?.endTime && (
-									<S.ItemDue>
-										마감:{" "}
-										{new Date(selectedQuiz.endTime).toLocaleString("ko-KR")}
-									</S.ItemDue>
-								)}
 							</div>
 						</S.CourseQuizHeader>
+						<th rowSpan={2}>전체 총점</th>
+						<th rowSpan={2}>비율</th>
 					</tr>
 					<tr>
 						{problemGrades.map((p) => (
@@ -172,12 +163,9 @@ export default function GradeManagementQuizTable({
 												</S.EditForm>
 											) : (
 												<S.ScoreDisplay>
-													<S.ScoreValue>
-														{`${problem.score ?? 0} / ${problem.points ?? 0}`}
-													</S.ScoreValue>
-													{canEdit && (
-														<S.ScoreActions>
-															<button
+													<S.ScoreRow>
+														{canEdit ? (
+															<S.ScoreValueButton
 																type="button"
 																onClick={() => {
 																	setEditingGrade({
@@ -195,31 +183,35 @@ export default function GradeManagementQuizTable({
 																}}
 																title="점수 입력/수정"
 															>
-																<FaEdit />
+																{`${problem.score ?? 0} / ${problem.points ?? 0}`}
+															</S.ScoreValueButton>
+														) : (
+															<S.ScoreValue>
+																{`${problem.score ?? 0} / ${problem.points ?? 0}`}
+															</S.ScoreValue>
+														)}
+														{canEdit && problem.submitted && handleViewCode && (
+															<button
+																type="button"
+																onClick={() =>
+																	handleViewCode(
+																		student.userId,
+																		problem.problemId,
+																	)
+																}
+																title="코드 조회"
+															>
+																<FaCode />
 															</button>
-															{problem.submitted && handleViewCode && (
-																<button
-																	type="button"
-																	onClick={() =>
-																		handleViewCode(
-																			student.userId,
-																			problem.problemId,
-																		)
-																	}
-																	title="코드 조회"
-																>
-																	<FaCode />
-																</button>
-															)}
-														</S.ScoreActions>
-													)}
-													{(problem.submitted || selectedQuiz?.endTime) && (
-														<S.SubmissionInfo>
-															{problem.submitted && (
+														)}
+														{(problem.submitted ||
+															(selectedQuiz?.endTime &&
+																new Date() > new Date(selectedQuiz.endTime))) &&
+															(problem.submitted ? (
 																<S.SubmissionStatus $onTime={problem.isOnTime}>
 																	{problem.isOnTime ? (
 																		<>
-																			<FaCheckCircle /> 정시 제출
+																			<FaCheckCircle />
 																		</>
 																	) : (
 																		<>
@@ -227,25 +219,12 @@ export default function GradeManagementQuizTable({
 																		</>
 																	)}
 																</S.SubmissionStatus>
-															)}
-															{selectedQuiz?.endTime && (
-																<S.SubmissionDue>
-																	<FaCalendarAlt /> 제출 기한:{" "}
-																	{new Date(
-																		selectedQuiz.endTime,
-																	).toLocaleString("ko-KR")}
-																</S.SubmissionDue>
-															)}
-															{problem.submittedAt && (
-																<S.SubmissionTime>
-																	<FaClock /> 제출 시간:{" "}
-																	{new Date(problem.submittedAt).toLocaleString(
-																		"ko-KR",
-																	)}
-																</S.SubmissionTime>
-															)}
-														</S.SubmissionInfo>
-													)}
+															) : (
+																<S.SubmissionStatus $onTime={false}>
+																	<FaTimesCircle />
+																</S.SubmissionStatus>
+															))}
+													</S.ScoreRow>
 												</S.ScoreDisplay>
 											)}
 										</S.TdCourseProblemCell>
@@ -256,11 +235,21 @@ export default function GradeManagementQuizTable({
 										{totalScore} / {totalPoints}
 									</strong>
 								</S.TdCourseAssignmentTotalCell>
+								<td>
+									<strong>
+										{totalScore} / {totalPoints}
+									</strong>
+								</td>
+								<td>
+									{totalPoints > 0
+										? `${((totalScore / totalPoints) * 100).toFixed(1)}%`
+										: "-"}
+								</td>
 							</tr>
 						);
 					})}
 				</tbody>
-			</S.CourseTable>
+			</S.CourseTableWithStickyRight>
 		</S.CourseTableContainer>
 	);
 }

--- a/src/pages/TutorPage/Grades/GradeManagement/styles.ts
+++ b/src/pages/TutorPage/Grades/GradeManagement/styles.ts
@@ -180,6 +180,10 @@ export const SecondaryButton = styled.button`
 export const STICKY_COL_1_WIDTH = "5.5rem";
 export const STICKY_COL_2_WIDTH = "6rem";
 
+/** 오른쪽 고정 열(전체 총점, 비율) - 수업 전체 보기 */
+export const STICKY_RIGHT_TOTAL_WIDTH = "4.5rem";
+export const STICKY_RIGHT_RATIO_WIDTH = "3.75rem";
+
 /** 스크롤 영역 열 고정 너비 - 갯수와 상관없이 간격 통일, 가로 스크롤로 확장 */
 export const COL_SCORE_WIDTH = "5rem";
 export const COL_PROBLEM_WIDTH = "13rem";
@@ -680,10 +684,33 @@ export const ScoreDisplay = styled.div`
   justify-content: center;
 `;
 
+export const ScoreRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+`;
+
 export const ScoreValue = styled.div`
   font-weight: 600;
   color: #667eea;
   font-size: 0.95rem;
+`;
+
+export const ScoreValueButton = styled.button`
+  font-weight: 600;
+  font-size: 0.95rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: #2563eb;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  &:hover {
+    color: #1d4ed8;
+  }
 `;
 
 export const ScoreActions = styled.div`
@@ -852,6 +879,58 @@ export const CourseTableContainer = styled(TableContainer)`
 `;
 
 export const CourseTable = styled(Table)``;
+
+/** 수업 전체 보기: 오른쪽에 전체 총점·비율 열 고정 */
+export const CourseTableWithStickyRight = styled(CourseTable)`
+  /* thead 첫 행: 마지막 두 열(전체 총점, 비율) 오른쪽 고정 */
+  thead tr:first-child th:nth-last-child(2) {
+    position: sticky !important;
+    right: ${STICKY_RIGHT_RATIO_WIDTH} !important;
+    z-index: 15 !important;
+    width: ${STICKY_RIGHT_TOTAL_WIDTH} !important;
+    min-width: ${STICKY_RIGHT_TOTAL_WIDTH} !important;
+    max-width: ${STICKY_RIGHT_TOTAL_WIDTH} !important;
+    box-shadow: -2px 0 4px rgba(0, 0, 0, 0.08);
+    background: #f8fafc !important;
+  }
+  thead tr:first-child th:nth-last-child(1) {
+    position: sticky !important;
+    right: 0 !important;
+    z-index: 15 !important;
+    width: ${STICKY_RIGHT_RATIO_WIDTH} !important;
+    min-width: ${STICKY_RIGHT_RATIO_WIDTH} !important;
+    max-width: ${STICKY_RIGHT_RATIO_WIDTH} !important;
+    box-shadow: -2px 0 4px rgba(0, 0, 0, 0.08);
+    background: #f8fafc !important;
+  }
+  /* thead 두 번째 행은 마지막 두 열이 rowSpan으로 비어 있음 */
+  tbody td:nth-last-child(2) {
+    position: sticky !important;
+    right: ${STICKY_RIGHT_RATIO_WIDTH} !important;
+    z-index: 1 !important;
+    width: ${STICKY_RIGHT_TOTAL_WIDTH} !important;
+    min-width: ${STICKY_RIGHT_TOTAL_WIDTH} !important;
+    max-width: ${STICKY_RIGHT_TOTAL_WIDTH} !important;
+    background: #f1f5f9 !important;
+    font-weight: 600 !important;
+    box-shadow: -2px 0 4px rgba(0, 0, 0, 0.08);
+  }
+  tbody td:nth-last-child(1) {
+    position: sticky !important;
+    right: 0 !important;
+    z-index: 1 !important;
+    width: ${STICKY_RIGHT_RATIO_WIDTH} !important;
+    min-width: ${STICKY_RIGHT_RATIO_WIDTH} !important;
+    max-width: ${STICKY_RIGHT_RATIO_WIDTH} !important;
+    background: #fff !important;
+    font-weight: 600 !important;
+    box-shadow: -2px 0 4px rgba(0, 0, 0, 0.08);
+  }
+  tbody tr:hover td:nth-last-child(2),
+  tbody tr:hover td:nth-last-child(1) {
+    background: #f8fafc !important;
+  }
+`;
 
 export const TdCourseProblemCell = styled.td`
   position: relative;

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -838,7 +838,7 @@ class APIService {
 	}
 
 	async createCourse(courseData: any): Promise<any> {
-		return await this.request("/admin/courses", {
+		return await this.request("/courses", {
 			method: "POST",
 			body: JSON.stringify(courseData),
 		});


### PR DESCRIPTION
## #️⃣연관된 이슈

#105 

# [성적 관리] 성적 관리 화면 개선

## 개요
성적 관리(튜터) 페이지의 테이블 UI·CSV 내보내기 동작을 개선했습니다.

---

## 변경 사항

### 1. 제출 상태 표시
- **마감 시간 이후 미제출**: 제출하지 않은 경우 빨간색 X + "미제출" 표시
- **정시 제출 / 기한 초과**: 기존 배지 유지 (숫자 옆에 배치)

### 2. 점수 수정 UX
- 점수 **숫자를 링크처럼** 표시 (파란색, 밑줄)
- **숫자 클릭 시** 해당 셀만 수정 모드로 전환 (기존 연필 버튼 제거)

### 3. 레이아웃
- **코드 보기 버튼**, **제출 지각 여부**(정시 제출 / 기한 초과 / 미제출)를 **점수 숫자와 한 줄**에 배치 (`ScoreRow`)

### 4. 전체 총점·비율 고정 열
- **오른쪽 고정 열** 추가: "전체 총점", "비율"
- 가로 스크롤 시에도 학생·학번(왼쪽)과 전체 총점·비율(오른쪽) 고정
- **수업 전체 / 전체 과제 / 전체 퀴즈**: 현재 필터(표시 중인 항목)만 반영해 총점·비율 계산
- **과제별 보기·퀴즈별 보기**: 선택한 과제/퀴즈 기준으로 총점·비율 표시

### 5. CSV 내보내기
- **제출일자**, **마감일자** 컬럼 추가 (문제별)
- 마감일 지나고 미제출 → 제출일자 칸에 **"미제출"** 표시
- 마감일 지나고 제출 → 제출일자에 실제 제출일시 표시
- 수업 전체 / 전체 과제 / 전체 퀴즈 / 단일 과제 / 단일 퀴즈 내보내기 모두 동일 적용

### 6. UI 정리
- **마감**, **제출 기한**, **제출 시간** 텍스트 표시 제거 (헤더·셀 하단)
- 정시 제출 / 기한 초과 / 미제출 배지는 유지

---

## 수정된 파일

| 경로 | 내용 |
|------|------|
| `GradeManagement/components/GradeManagementAssignmentTable.tsx` | 과제별 테이블: 미제출 표시, 점수 링크, ScoreRow, 오른쪽 고정 열, 마감/제출기한·제출시간 제거 |
| `GradeManagement/components/GradeManagementCourseTable.tsx` | 수업 전체 테이블: 동일 UI 개선, 필터 반영 총점·비율, 오른쪽 고정 열 |
| `GradeManagement/components/GradeManagementQuizTable.tsx` | 퀴즈별 테이블: 동일 적용 |
| `GradeManagement/hooks/useGradeManagement.ts` | CSV 내보내기: 제출일자·마감일자·미제출 컬럼 추가 (모든 보기 모드) |
| `GradeManagement/styles.ts` | `ScoreRow`, `ScoreValueButton`, `CourseTableWithStickyRight`, 오른쪽 고정 열 스타일 (`STICKY_RIGHT_*`) |

---

## 참고
- 브랜치: `fix/issue-105/APIservice`
- APIService.ts 변경 사항은 이 이슈 범위와 별도일 수 있음 (필요 시 분리 기술)
