### PR TITLE
문제 추가 모달 – 복사본 제목 기준 중복 제거 제거

### DIFF
--- a/src/layouts/TutorLayout/index.tsx
+++ b/src/layouts/TutorLayout/index.tsx
@@ -26,6 +26,7 @@ import {
 	FaArrowLeft,
 	FaCode,
 	FaChevronLeft,
+	FaLink,
 } from "react-icons/fa";
 import * as S from "./styles";
 import type { Section, MenuItem, ExpandedMenus } from "./types";
@@ -58,6 +59,14 @@ const TutorLayout: React.FC<TutorLayoutProps> = ({
 		const saved = localStorage.getItem("tutor_sidebarCollapsed");
 		return saved === "true";
 	});
+
+	const handleCopyTutorLink = useCallback(() => {
+		const tutorLink = `${window.location.origin}/tutor`;
+		navigator.clipboard
+			.writeText(tutorLink)
+			.then(() => alert("수업 링크가 복사되었습니다."))
+			.catch(() => alert("링크 복사에 실패했습니다."));
+	}, []);
 
 	useEffect(() => {
 		localStorage.setItem("tutor_expandedMenus", JSON.stringify(expandedMenus));
@@ -647,6 +656,15 @@ const TutorLayout: React.FC<TutorLayoutProps> = ({
 											<S.SidebarSectionTitle $collapsed={sidebarCollapsed}>
 												수업 관리
 											</S.SidebarSectionTitle>
+											<S.SidebarLinkCopyBtn
+												$collapsed={sidebarCollapsed}
+												type="button"
+												onClick={handleCopyTutorLink}
+												title={sidebarCollapsed ? "수업 링크 복사" : ""}
+											>
+												<FaLink />
+												{!sidebarCollapsed && "수업 링크 복사"}
+											</S.SidebarLinkCopyBtn>
 											{sectionMenuItems.map((item) =>
 												renderMenuItem(item, true),
 											)}

--- a/src/layouts/TutorLayout/styles.ts
+++ b/src/layouts/TutorLayout/styles.ts
@@ -639,6 +639,37 @@ export const SectionCardEmptyText = styled.div<{ $collapsed: boolean }>`
     width 0.3s cubic-bezier(0.4, 0, 0.2, 1), height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 `;
 
+export const SidebarLinkCopyBtn = styled.button<{ $collapsed: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: ${(props) => (props.$collapsed ? "0.625rem 0" : "0.5rem 0.75rem")};
+  width: ${(props) => (props.$collapsed ? "100%" : "auto")};
+  margin-bottom: 0.25rem;
+  border: none;
+  background: transparent;
+  color: #6b7280;
+  font-size: 0.9rem;
+  font-weight: 500;
+  font-family: "Pretendard", -apple-system, BlinkMacSystemFont, system-ui, Roboto, sans-serif;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+  min-height: 2.25rem;
+  box-sizing: border-box;
+
+  &:hover {
+    background-color: #f3f4f6;
+    color: #667eea;
+  }
+
+  svg {
+    flex-shrink: 0;
+    font-size: 1rem;
+  }
+`;
+
 export const SidebarSectionMenuWrapper = styled.div<{ $visible: boolean }>`
   display: grid;
   grid-template-rows: ${(props) => (props.$visible ? "1fr" : "0fr")};

--- a/src/pages/TutorPage/Assignments/AssignmentCreatePage/index.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentCreatePage/index.tsx
@@ -1,5 +1,7 @@
 import type { FC } from "react";
+import { createPortal } from "react-dom";
 import TutorLayout from "../../../../layouts/TutorLayout";
+import LoadingSpinner from "../../../../components/UI/LoadingSpinner";
 import { useAssignmentCreate } from "./hooks/useAssignmentCreate";
 import * as S from "./styles";
 import AssignmentCreateForm from "./components/AssignmentCreateForm";
@@ -16,6 +18,32 @@ const AssignmentCreatePage: FC = () => {
 
 	return (
 		<TutorLayout selectedSection={currentSection}>
+			{loading &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="과제 생성 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Page>
 				<S.Header>
 					<S.BackButton type="button" onClick={handleBack}>

--- a/src/pages/TutorPage/Assignments/AssignmentEditPage/index.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentEditPage/index.tsx
@@ -1,4 +1,5 @@
 import type { FC } from "react";
+import { createPortal } from "react-dom";
 import TutorLayout from "../../../../layouts/TutorLayout";
 import LoadingSpinner from "../../../../components/UI/LoadingSpinner";
 import { useAssignmentEdit } from "./hooks/useAssignmentEdit";
@@ -26,6 +27,32 @@ const AssignmentEditPage: FC = () => {
 
 	return (
 		<TutorLayout selectedSection={currentSection}>
+			{submitting &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="과제 수정 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Page>
 				<S.Header>
 					<S.BackButton type="button" onClick={handleBack}>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentManagementHeader.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentManagementHeader.tsx
@@ -11,6 +11,8 @@ interface AssignmentManagementHeaderProps {
 	onAddAssignment: () => void;
 	onStandaloneProblemCreate: () => void;
 	onBulkProblemCreate: () => void;
+	/** 조교(TUTOR)인 수업이면 과제 추가/수정 등 제한 */
+	isTutorOnly?: boolean;
 }
 
 const AssignmentManagementHeader: React.FC<AssignmentManagementHeaderProps> = ({
@@ -23,6 +25,7 @@ const AssignmentManagementHeader: React.FC<AssignmentManagementHeaderProps> = ({
 	onAddAssignment,
 	onStandaloneProblemCreate,
 	onBulkProblemCreate,
+	isTutorOnly,
 }) => {
 	/* 2번 사진 원본: 헤더에 제목 + 오른쪽 "과제 추가하기" 버튼만, 뱃지 없음 */
 	if (sectionId) {
@@ -32,11 +35,13 @@ const AssignmentManagementHeader: React.FC<AssignmentManagementHeaderProps> = ({
 					<S.HeaderLeft>
 						<S.PageTitle>과제 관리</S.PageTitle>
 					</S.HeaderLeft>
-					<S.HeaderActions>
-						<S.BtnPrimary type="button" onClick={onAddAssignment}>
-							과제 추가하기
-						</S.BtnPrimary>
-					</S.HeaderActions>
+					{!isTutorOnly && (
+						<S.HeaderActions>
+							<S.BtnPrimary type="button" onClick={onAddAssignment}>
+								과제 추가하기
+							</S.BtnPrimary>
+						</S.HeaderActions>
+					)}
 				</S.PageHeader>
 				<S.FiltersSection>
 					<S.SearchBox>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/AssignmentAddModal.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/AssignmentAddModal.tsx
@@ -27,6 +27,7 @@ interface AssignmentAddModalProps {
 			HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
 		>,
 	) => void;
+	loading?: boolean;
 }
 
 const AssignmentAddModal: React.FC<AssignmentAddModalProps> = ({
@@ -36,6 +37,7 @@ const AssignmentAddModal: React.FC<AssignmentAddModalProps> = ({
 	onClose,
 	onSubmit,
 	onInputChange,
+	loading = false,
 }) => {
 	if (!isOpen) return null;
 
@@ -130,10 +132,16 @@ const AssignmentAddModal: React.FC<AssignmentAddModalProps> = ({
 					</S.FormRow>
 
 					<S.FormActions>
-						<S.ButtonSecondary type="button" onClick={onClose}>
+						<S.ButtonSecondary
+							type="button"
+							onClick={onClose}
+							disabled={loading}
+						>
 							취소
 						</S.ButtonSecondary>
-						<S.ButtonPrimary type="submit">과제 생성</S.ButtonPrimary>
+						<S.ButtonPrimary type="submit" disabled={loading}>
+							{loading ? "생성 중..." : "과제 생성"}
+						</S.ButtonPrimary>
 					</S.FormActions>
 				</S.Form>
 			</S.ModalContent>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/AssignmentEditModal.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/AssignmentEditModal.tsx
@@ -34,6 +34,7 @@ interface AssignmentEditModalProps {
 	onInputChange: (
 		e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
 	) => void;
+	loading?: boolean;
 }
 
 const AssignmentEditModal: React.FC<AssignmentEditModalProps> = ({
@@ -44,6 +45,7 @@ const AssignmentEditModal: React.FC<AssignmentEditModalProps> = ({
 	onClose,
 	onSubmit,
 	onInputChange,
+	loading = false,
 }) => {
 	if (!isOpen) return null;
 
@@ -120,10 +122,16 @@ const AssignmentEditModal: React.FC<AssignmentEditModalProps> = ({
 					</S.FormRow>
 
 					<S.FormActions>
-						<S.ButtonSecondary type="button" onClick={onClose}>
+						<S.ButtonSecondary
+							type="button"
+							onClick={onClose}
+							disabled={loading}
+						>
 							취소
 						</S.ButtonSecondary>
-						<S.ButtonPrimary type="submit">수정 완료</S.ButtonPrimary>
+						<S.ButtonPrimary type="submit" disabled={loading}>
+							{loading ? "수정 중..." : "수정 완료"}
+						</S.ButtonPrimary>
 					</S.FormActions>
 				</S.Form>
 			</S.ModalContent>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx
@@ -53,10 +53,13 @@ interface AssignmentListViewProps {
 	) => void;
 	onDelete: (assignmentId: number) => void;
 	onRemoveProblem: (assignmentId: number, problemId: number) => void;
+	/** 조교(TUTOR) 전용 수업이면 수정/비활성화/삭제/문제추가 비표시 */
+	isTutorOnly?: boolean;
 }
 
 /**
  * 과제 리스트 뷰 컴포넌트 (전체 페이지용)
+ * 스타일: 상위 AssignmentManagement/styles.ts 의 ListViewWrapper (tutor-assignments-*, tutor-more-* 등)
  */
 const AssignmentListView: React.FC<AssignmentListViewProps> = ({
 	filteredAssignments,
@@ -72,6 +75,7 @@ const AssignmentListView: React.FC<AssignmentListViewProps> = ({
 	onToggleActive,
 	onDelete,
 	onRemoveProblem,
+	isTutorOnly,
 }) => {
 	return (
 		<div className="tutor-assignments-list">
@@ -129,58 +133,62 @@ const AssignmentListView: React.FC<AssignmentListViewProps> = ({
 									? "문제 목록 숨기기"
 									: "문제 목록 보기"}
 							</button>
-							<button
-								className="tutor-btn-list-action"
-								onClick={() => onAddProblem(assignment)}
-							>
-								문제 추가
-							</button>
-							<button
-								className="tutor-btn-list-action"
-								onClick={() => onEdit(assignment)}
-							>
-								수정
-							</button>
-							<div className="tutor-more-menu">
-								<button
-									className="tutor-btn-list-action tutor-btn-more"
-									title="더보기"
-									onClick={(e) => {
-										e.stopPropagation();
-										onToggleMoreMenu(assignment.id);
-									}}
-								>
-									⋯
-								</button>
-								{openMoreMenu === assignment.id && (
-									<div className="tutor-more-dropdown">
+							{!isTutorOnly && (
+								<>
+									<button
+										className="tutor-btn-list-action"
+										onClick={() => onAddProblem(assignment)}
+									>
+										문제 추가
+									</button>
+									<button
+										className="tutor-btn-list-action"
+										onClick={() => onEdit(assignment)}
+									>
+										수정
+									</button>
+									<div className="tutor-more-menu">
 										<button
-											className="tutor-btn-text-small"
+											className="tutor-btn-list-action tutor-btn-more"
+											title="더보기"
 											onClick={(e) => {
 												e.stopPropagation();
-												onToggleActive(
-													assignment.sectionId,
-													assignment.id,
-													assignment.active,
-												);
-												onToggleMoreMenu(null);
+												onToggleMoreMenu(assignment.id);
 											}}
 										>
-											{assignment.active ? "비활성화" : "활성화"}
+											⋯
 										</button>
-										<button
-											className="tutor-btn-text-small tutor-delete"
-											onClick={(e) => {
-												e.stopPropagation();
-												onDelete(assignment.id);
-												onToggleMoreMenu(null);
-											}}
-										>
-											삭제
-										</button>
+										{openMoreMenu === assignment.id && (
+											<div className="tutor-more-dropdown">
+												<button
+													className="tutor-btn-text-small"
+													onClick={(e) => {
+														e.stopPropagation();
+														onToggleActive(
+															assignment.sectionId,
+															assignment.id,
+															assignment.active,
+														);
+														onToggleMoreMenu(null);
+													}}
+												>
+													{assignment.active ? "비활성화" : "활성화"}
+												</button>
+												<button
+													className="tutor-btn-text-small tutor-delete"
+													onClick={(e) => {
+														e.stopPropagation();
+														onDelete(assignment.id);
+														onToggleMoreMenu(null);
+													}}
+												>
+													삭제
+												</button>
+											</div>
+										)}
 									</div>
-								)}
-							</div>
+								</>
+							)}
 						</div>
 					</div>
 
@@ -239,26 +247,30 @@ const AssignmentListView: React.FC<AssignmentListViewProps> = ({
 														: `제출 현황: 0/${submissionStats[assignment.id]?.totalStudents || assignment.totalStudents || 0}`}
 												</span>
 
-												<button
-													className="tutor-btn-remove-problem"
-													onClick={() =>
-														onRemoveProblem(assignment.id, problem.id)
-													}
-													title="문제 제거"
-												>
-													✕
-												</button>
+												{!isTutorOnly && (
+													<button
+														className="tutor-btn-remove-problem"
+														onClick={() =>
+															onRemoveProblem(assignment.id, problem.id)
+														}
+														title="문제 제거"
+													>
+														✕
+													</button>
+												)}
 											</div>
 										))
 									) : (
 										<div className="tutor-no-problems">
 											<p>등록된 문제가 없습니다.</p>
-											<button
-												className="tutor-btn-add-first-problem"
-												onClick={() => onAddProblem(assignment)}
-											>
-												첫 번째 문제 추가하기
-											</button>
+											{!isTutorOnly && (
+												<button
+													className="tutor-btn-add-first-problem"
+													onClick={() => onAddProblem(assignment)}
+												>
+													첫 번째 문제 추가하기
+												</button>
+											)}
 										</div>
 									)}
 								</div>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx
@@ -44,10 +44,13 @@ interface AssignmentTableViewProps {
 	) => void;
 	onDelete: (assignmentId: number) => void;
 	paginationProps: PaginationProps;
+	/** 조교(TUTOR) 전용 수업이면 수정/비활성화/삭제/문제추가 비표시 */
+	isTutorOnly?: boolean;
 }
 
 /**
  * 과제 테이블 뷰 컴포넌트 (분반별 페이지용)
+ * 스타일: 상위 AssignmentManagement/styles.ts 의 TableViewWrapper (tutor-assignments-*, tutor-more-* 등)
  */
 const AssignmentTableView: React.FC<AssignmentTableViewProps> = ({
 	paginatedAssignments,
@@ -60,6 +63,7 @@ const AssignmentTableView: React.FC<AssignmentTableViewProps> = ({
 	onToggleActive,
 	onDelete,
 	paginationProps,
+	isTutorOnly,
 }) => {
 	return (
 		<div className="tutor-assignments-table-container">
@@ -116,85 +120,91 @@ const AssignmentTableView: React.FC<AssignmentTableViewProps> = ({
 										: `0/${assignment.totalStudents || 0}`}
 								</td>
 								<td className="tutor-assignment-actions-cell">
-									<div className="tutor-assignment-actions-inline">
-										<div className="tutor-assignment-primary-actions">
-											<button
-												type="button"
-												className="tutor-btn-table-action"
-												onClick={() => onProblemListManage(assignment)}
-												title="문제 목록 관리"
-											>
-												목록
-											</button>
-											<button
-												type="button"
-												className="tutor-btn-table-action"
-												onClick={() => onAddProblem(assignment)}
-												title="문제 추가"
-											>
-												추가
-											</button>
-											<button
-												type="button"
-												className="tutor-btn-table-action tutor-btn-edit"
-												onClick={() => onEdit(assignment)}
-												title="수정"
-											>
-												수정
-											</button>
-										</div>
-										<div className="tutor-assignment-secondary-actions">
-											<div className="tutor-secondary-actions-layer">
+									{isTutorOnly ? (
+										<span className="tutor-assignment-view-only">
+											조회 전용
+										</span>
+									) : (
+										<div className="tutor-assignment-actions-inline">
+											<div className="tutor-assignment-primary-actions">
 												<button
 													type="button"
-													className="tutor-btn-table-action tutor-btn-secondary-action"
-													onClick={(e) => {
-														e.stopPropagation();
-														onToggleActive(
-															assignment.sectionId,
-															assignment.id,
-															assignment.active,
-														);
-													}}
-													title={assignment.active ? "비활성화" : "활성화"}
+													className="tutor-btn-table-action"
+													onClick={() => onProblemListManage(assignment)}
+													title="문제 목록 관리"
 												>
-													{assignment.active ? "비활성화" : "활성화"}
+													목록
 												</button>
-												<div className="tutor-more-menu">
+												<button
+													type="button"
+													className="tutor-btn-table-action"
+													onClick={() => onAddProblem(assignment)}
+													title="문제 추가"
+												>
+													추가
+												</button>
+												<button
+													type="button"
+													className="tutor-btn-table-action tutor-btn-edit"
+													onClick={() => onEdit(assignment)}
+													title="수정"
+												>
+													수정
+												</button>
+											</div>
+											<div className="tutor-assignment-secondary-actions">
+												<div className="tutor-secondary-actions-layer">
 													<button
 														type="button"
-														className="tutor-btn-table-action tutor-btn-secondary-action tutor-btn-more"
+														className="tutor-btn-table-action tutor-btn-secondary-action"
 														onClick={(e) => {
 															e.stopPropagation();
-															onToggleMoreMenu(
-																openMoreMenu === assignment.id
-																	? null
-																	: assignment.id,
+															onToggleActive(
+																assignment.sectionId,
+																assignment.id,
+																assignment.active,
 															);
 														}}
-														title="더보기"
+														title={assignment.active ? "비활성화" : "활성화"}
 													>
-														⋯
+														{assignment.active ? "비활성화" : "활성화"}
 													</button>
-													{openMoreMenu === assignment.id && (
-														<div className="tutor-more-dropdown">
-															<button
-																type="button"
-																className="tutor-btn-text-small tutor-delete"
-																onClick={(e) => {
-																	e.stopPropagation();
-																	onDelete(assignment.id);
-																	onToggleMoreMenu(null);
-																}}
-															>
-																삭제
-															</button>
-														</div>
-													)}
+													<div className="tutor-more-menu">
+														<button
+															type="button"
+															className="tutor-btn-table-action tutor-btn-secondary-action tutor-btn-more"
+															onClick={(e) => {
+																e.stopPropagation();
+																onToggleMoreMenu(
+																	openMoreMenu === assignment.id
+																		? null
+																		: assignment.id,
+																);
+															}}
+															title="더보기"
+														>
+															⋯
+														</button>
+														{openMoreMenu === assignment.id && (
+															<div className="tutor-more-dropdown">
+																<button
+																	type="button"
+																	className="tutor-btn-text-small tutor-delete"
+																	onClick={(e) => {
+																		e.stopPropagation();
+																		onDelete(assignment.id);
+																		onToggleMoreMenu(null);
+																	}}
+																>
+																	삭제
+																</button>
+															</div>
+														)}
+													</div>
 												</div>
 											</div>
 										</div>
-									</div>
+									)}
 								</td>
 							</tr>
 						))

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/index.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/index.tsx
@@ -32,6 +32,40 @@ const AssignmentManagement: React.FC = () => {
 
 	return (
 		<TutorLayout selectedSection={d.currentSection as SectionInfo | null}>
+			{(d.isAddingProblems || d.isSubmittingAdd || d.isSubmittingEdit) &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner
+								message={
+									d.isAddingProblems
+										? "문제 추가 중..."
+										: d.isSubmittingAdd
+											? "과제 생성 중..."
+											: "과제 수정 중..."
+								}
+							/>
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Container>
 				<AssignmentManagementHeader
 					sectionId={d.sectionId}
@@ -43,6 +77,7 @@ const AssignmentManagement: React.FC = () => {
 					onAddAssignment={d.handleAddAssignment}
 					onStandaloneProblemCreate={d.handleStandaloneProblemCreate}
 					onBulkProblemCreate={d.handleBulkProblemCreate}
+					isTutorOnly={d.isTutorOnly}
 				/>
 
 				{d.sectionId ? (
@@ -68,6 +103,7 @@ const AssignmentManagement: React.FC = () => {
 							onEdit={d.handleEdit}
 							onToggleActive={d.handleToggleActive}
 							onDelete={d.handleDelete}
+							isTutorOnly={d.isTutorOnly}
 							paginationProps={{
 								currentPage: d.currentPage,
 								totalItems: d.filteredAssignments.length,
@@ -108,6 +144,7 @@ const AssignmentManagement: React.FC = () => {
 							onToggleActive={d.handleToggleActive}
 							onDelete={d.handleDelete}
 							onRemoveProblem={d.handleRemoveProblem}
+							isTutorOnly={d.isTutorOnly}
 						/>
 					</S.ListViewWrapper>
 				)}
@@ -120,6 +157,7 @@ const AssignmentManagement: React.FC = () => {
 				onClose={d.handleCloseAddModal}
 				onSubmit={d.handleSubmitAdd}
 				onInputChange={d.handleInputChange}
+				loading={d.isSubmittingAdd}
 			/>
 
 			<AssignmentEditModal
@@ -130,6 +168,7 @@ const AssignmentManagement: React.FC = () => {
 				onClose={d.handleCloseEditModal}
 				onSubmit={d.handleSubmitEdit}
 				onInputChange={d.handleInputChange}
+				loading={d.isSubmittingEdit}
 			/>
 
 			<ProblemSelectModal
@@ -211,12 +250,8 @@ const AssignmentManagement: React.FC = () => {
 						}}
 						assignmentsForProblem={d.assignmentsForProblem}
 						assignmentProblems={d.assignmentProblems}
-						expandedAssignmentsForProblem={
-							d.expandedAssignmentsForProblem
-						}
-						loadingAssignmentsForProblem={
-							d.loadingAssignmentsForProblem
-						}
+						expandedAssignmentsForProblem={d.expandedAssignmentsForProblem}
+						loadingAssignmentsForProblem={d.loadingAssignmentsForProblem}
 						copyProblemSearchTerm={d.copyProblemSearchTerm}
 						onCopyProblemSearchTermChange={d.setCopyProblemSearchTerm}
 						problemViewMode={d.problemViewMode}
@@ -238,9 +273,7 @@ const AssignmentManagement: React.FC = () => {
 							d.closeCopyModal();
 						}}
 						onSelectAllInList={d.setSelectedProblemIds}
-						onOpenProblemDetail={(detail) =>
-							d.setSelectedProblemDetail(detail)
-						}
+						onOpenProblemDetail={(detail) => d.setSelectedProblemDetail(detail)}
 					/>,
 					document.body,
 				)}

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/styles.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/styles.ts
@@ -564,7 +564,7 @@ export const CopyFooterBtnPrimary = styled(BtnPrimary)`
 export const TableViewWrapper = styled.div`
   .tutor-assignments-table-container {
     margin-top: 0;
-    overflow-x: auto;
+    /* overflow 제거: 내부 더보기(⋯) 드롭다운이 잘리지 않도록 (가로 스크롤 필요 시 페이지 전체 스크롤) */
     border: 1px solid #e5e7eb;
     border-radius: 12px;
     background: white;
@@ -668,6 +668,11 @@ export const TableViewWrapper = styled.div`
   .tutor-assignment-actions-cell {
     white-space: nowrap;
     text-align: right;
+  }
+
+  .tutor-assignment-view-only {
+    color: #64748b;
+    font-size: 0.875rem;
   }
 
   .tutor-assignment-actions-inline {
@@ -846,7 +851,7 @@ export const ListViewWrapper = styled.div`
     background: white;
     border: 2px solid #e5e7eb;
     border-radius: 12px;
-    overflow: hidden;
+    overflow: visible;
     transition: all 0.2s ease;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
   }

--- a/src/pages/TutorPage/CodingTests/CodingTestManagement/components/CodingTestManagementView.tsx
+++ b/src/pages/TutorPage/CodingTests/CodingTestManagement/components/CodingTestManagementView.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { createPortal } from "react-dom";
 import TutorLayout from "../../../../../layouts/TutorLayout";
 import SectionNavigation from "../../../../../components/Navigation/SectionNavigation";
 import LoadingSpinner from "../../../../../components/UI/LoadingSpinner";
@@ -631,6 +632,38 @@ export default function CodingTestManagementView(
 
 	return (
 		<TutorLayout selectedSection={d.currentSection}>
+			{(d.isSubmittingCreate || d.isSubmittingEdit) &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner
+								message={
+									d.isSubmittingCreate
+										? "코딩 테스트 생성 중..."
+										: "코딩 테스트 수정 중..."
+								}
+							/>
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Container>
 				{d.currentSection && d.sectionId && (
 					<SectionNavigation
@@ -857,8 +890,12 @@ export default function CodingTestManagementView(
 									>
 										취소
 									</S.CancelButton>
-									<S.SubmitButton type="button" onClick={d.handleSubmitCreate}>
-										생성
+									<S.SubmitButton
+										type="button"
+										onClick={d.handleSubmitCreate}
+										disabled={d.isSubmittingCreate}
+									>
+										{d.isSubmittingCreate ? "생성 중..." : "생성"}
 									</S.SubmitButton>
 								</S.ModalFooter>
 							</S.ModalBody>
@@ -984,8 +1021,12 @@ export default function CodingTestManagementView(
 									>
 										취소
 									</S.CancelButton>
-									<S.SubmitButton type="button" onClick={d.handleSubmitEdit}>
-										수정
+									<S.SubmitButton
+										type="button"
+										onClick={d.handleSubmitEdit}
+										disabled={d.isSubmittingEdit}
+									>
+										{d.isSubmittingEdit ? "수정 중..." : "수정"}
 									</S.SubmitButton>
 								</S.ModalFooter>
 							</S.ModalBody>

--- a/src/pages/TutorPage/CodingTests/CodingTestManagement/hooks/useCodingTestManagement.ts
+++ b/src/pages/TutorPage/CodingTests/CodingTestManagement/hooks/useCodingTestManagement.ts
@@ -47,6 +47,8 @@ export function useCodingTestManagement() {
 	const [allProblems, setAllProblems] = useState<ProblemOption[]>([]);
 	const [problemSearchTerm, setProblemSearchTerm] = useState("");
 	const [currentProblemPage, setCurrentProblemPage] = useState(1);
+	const [isSubmittingCreate, setIsSubmittingCreate] = useState(false);
+	const [isSubmittingEdit, setIsSubmittingEdit] = useState(false);
 
 	const fetchQuizzes = useCallback(async () => {
 		if (!sectionId) return;
@@ -227,7 +229,8 @@ export function useCodingTestManagement() {
 	}, [getFilteredProblems, currentProblemPage]);
 
 	const getTotalPages = useCallback(
-		(): number => Math.ceil(getFilteredProblems().length / PROBLEMS_PER_PAGE) || 1,
+		(): number =>
+			Math.ceil(getFilteredProblems().length / PROBLEMS_PER_PAGE) || 1,
 		[getFilteredProblems],
 	);
 
@@ -350,6 +353,7 @@ export function useCodingTestManagement() {
 			return;
 		}
 		if (!sectionId) return;
+		setIsSubmittingCreate(true);
 		try {
 			const copiedProblemIds: number[] = [];
 			for (const problemId of selectedProblemIds) {
@@ -374,6 +378,8 @@ export function useCodingTestManagement() {
 		} catch (error) {
 			console.error("코딩 테스트 생성 실패:", error);
 			alert("코딩 테스트 생성에 실패했습니다.");
+		} finally {
+			setIsSubmittingCreate(false);
 		}
 	}, [
 		formData.title,
@@ -399,6 +405,7 @@ export function useCodingTestManagement() {
 			return;
 		}
 		if (!selectedQuiz || !sectionId) return;
+		setIsSubmittingEdit(true);
 		try {
 			const copiedProblemIds: number[] = [];
 			for (const problemId of selectedProblemIds) {
@@ -424,6 +431,8 @@ export function useCodingTestManagement() {
 		} catch (error) {
 			console.error("코딩 테스트 수정 실패:", error);
 			alert("코딩 테스트 수정에 실패했습니다.");
+		} finally {
+			setIsSubmittingEdit(false);
 		}
 	}, [
 		formData.title,
@@ -448,8 +457,7 @@ export function useCodingTestManagement() {
 		setSelectedProblemIds((prev) => {
 			const filtered = getFilteredProblems();
 			const allSelected =
-				filtered.length > 0 &&
-				filtered.every((p) => prev.includes(p.id));
+				filtered.length > 0 && filtered.every((p) => prev.includes(p.id));
 			if (allSelected) {
 				const filteredIds = filtered.map((p) => p.id);
 				return prev.filter((id) => !filteredIds.includes(id));
@@ -459,12 +467,17 @@ export function useCodingTestManagement() {
 		});
 	}, [getFilteredProblems]);
 
-	const handleRemoveProblemFromQuiz = useCallback(async (_problemId: number) => {
-		if (!window.confirm("정말로 이 문제를 코딩테스트에서 제거하시겠습니까?")) {
-			return;
-		}
-		alert("문제 제거 기능은 백엔드 API 구현이 필요합니다.");
-	}, []);
+	const handleRemoveProblemFromQuiz = useCallback(
+		async (_problemId: number) => {
+			if (
+				!window.confirm("정말로 이 문제를 코딩테스트에서 제거하시겠습니까?")
+			) {
+				return;
+			}
+			alert("문제 제거 기능은 백엔드 API 구현이 필요합니다.");
+		},
+		[],
+	);
 
 	const closeProblemModal = useCallback(() => {
 		setShowProblemModal(false);
@@ -619,6 +632,8 @@ export function useCodingTestManagement() {
 		handleEditQuiz,
 		handleDeleteQuiz,
 		handleSubmitCreate,
+		isSubmittingCreate,
+		isSubmittingEdit,
 		handleSubmitEdit,
 		handleProblemToggle,
 		handleSelectAllProblems,

--- a/src/pages/TutorPage/Dashboard/components/CopySectionModal.tsx
+++ b/src/pages/TutorPage/Dashboard/components/CopySectionModal.tsx
@@ -11,6 +11,7 @@ import type {
 interface CopySectionModalProps {
 	isOpen: boolean;
 	onClose: () => void;
+	loading?: boolean;
 	copyStep: number;
 	setCopyStep: React.Dispatch<React.SetStateAction<number>>;
 	copyFormData: DashboardCopyFormData;
@@ -54,6 +55,7 @@ const CopySectionModal: React.FC<CopySectionModalProps> = (props) => {
 	const {
 		isOpen,
 		onClose,
+		loading = false,
 		copyStep,
 		setCopyStep,
 		copyFormData,
@@ -648,15 +650,24 @@ const CopySectionModal: React.FC<CopySectionModalProps> = (props) => {
 				</S.ModalBody>
 				<S.ModalFooter>
 					{copyStep > 1 && (
-						<S.BtnCancel onClick={() => setCopyStep(copyStep - 1)}>
+						<S.BtnCancel
+							onClick={() => setCopyStep(copyStep - 1)}
+							disabled={loading}
+						>
 							이전
 						</S.BtnCancel>
 					)}
-					<S.BtnCancel onClick={onClose}>취소</S.BtnCancel>
+					<S.BtnCancel onClick={onClose} disabled={loading}>
+						취소
+					</S.BtnCancel>
 					{copyStep < 4 ? (
-						<S.BtnSubmit onClick={handleNext}>다음</S.BtnSubmit>
+						<S.BtnSubmit onClick={handleNext} disabled={loading}>
+							다음
+						</S.BtnSubmit>
 					) : (
-						<S.BtnSubmit onClick={handleCopySection}>복사하기</S.BtnSubmit>
+						<S.BtnSubmit onClick={handleCopySection} disabled={loading}>
+							{loading ? "복사 중..." : "복사하기"}
+						</S.BtnSubmit>
 					)}
 				</S.ModalFooter>
 			</S.ModalContent>

--- a/src/pages/TutorPage/Dashboard/components/DashboardHeader.tsx
+++ b/src/pages/TutorPage/Dashboard/components/DashboardHeader.tsx
@@ -4,6 +4,8 @@ import * as S from "../styles";
 interface DashboardHeaderProps {
 	totalCount: number;
 	displayCount: number;
+	/** ADMIN인 수업이 하나라도 있을 때만 true (튜터 전용이면 복사 버튼 숨김) */
+	canCopySection: boolean;
 	onCopy: () => void;
 	onCreate: () => void;
 }
@@ -11,6 +13,7 @@ interface DashboardHeaderProps {
 const DashboardHeader: React.FC<DashboardHeaderProps> = ({
 	totalCount,
 	displayCount,
+	canCopySection,
 	onCopy,
 	onCreate,
 }) => (
@@ -23,7 +26,9 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
 			</S.TitleStats>
 		</S.TitleLeft>
 		<S.TitleRight>
-			<S.CopyButton onClick={onCopy}>기존 수업 복사</S.CopyButton>
+			{canCopySection && (
+				<S.CopyButton onClick={onCopy}>기존 수업 복사</S.CopyButton>
+			)}
 			<S.CreateButton onClick={onCreate}>+ 새 수업 만들기</S.CreateButton>
 		</S.TitleRight>
 	</S.TitleHeader>

--- a/src/pages/TutorPage/Dashboard/components/SectionCard.tsx
+++ b/src/pages/TutorPage/Dashboard/components/SectionCard.tsx
@@ -21,6 +21,7 @@ const SectionCard: React.FC<SectionCardProps> = ({
 }) => {
 	const navigate = useNavigate();
 	const isActive = section.active !== false;
+	const isTutorOnly = section.roleInSection === "TUTOR";
 
 	return (
 		<S.CourseCard key={section.sectionId}>
@@ -29,6 +30,11 @@ const SectionCard: React.FC<SectionCardProps> = ({
 				<S.StatusBadge $active={isActive}>
 					{isActive ? "활성" : "비활성"}
 				</S.StatusBadge>
+				{isTutorOnly && (
+					<S.StatusBadge $active={false} title="조회·일부 기능만 가능">
+						조교
+					</S.StatusBadge>
+				)}
 			</S.CardHeader>
 			<S.StatsCompact>
 				<S.StatItem>
@@ -54,13 +60,15 @@ const SectionCard: React.FC<SectionCardProps> = ({
 				)}
 			</S.StatsCompact>
 			<S.ActionsCompact>
-				<S.ToggleButton
-					$active={isActive}
-					onClick={() => onToggleActive(section.sectionId, isActive)}
-					title={isActive ? "비활성화하기" : "활성화하기"}
-				>
-					{isActive ? "활성" : "비활성"}
-				</S.ToggleButton>
+				{!isTutorOnly && (
+					<S.ToggleButton
+						$active={isActive}
+						onClick={() => onToggleActive(section.sectionId, isActive)}
+						title={isActive ? "비활성화하기" : "활성화하기"}
+					>
+						{isActive ? "활성" : "비활성"}
+					</S.ToggleButton>
+				)}
 				<S.ActionButtonsCompact>
 					<S.ActionButton
 						onClick={() =>
@@ -109,16 +117,18 @@ const SectionCard: React.FC<SectionCardProps> = ({
 						</S.DropdownToggle>
 						{openDropdownId === section.sectionId && (
 							<S.DropdownMenu>
-								<S.DropdownItem
-									$delete
-									onClick={(e) => {
-										e.stopPropagation();
-										onDropdownToggle(0);
-										onDelete(section.sectionId, section.courseTitle);
-									}}
-								>
-									삭제
-								</S.DropdownItem>
+								{!isTutorOnly && (
+									<S.DropdownItem
+										$delete
+										onClick={(e) => {
+											e.stopPropagation();
+											onDropdownToggle(0);
+											onDelete(section.sectionId, section.courseTitle);
+										}}
+									>
+										삭제
+									</S.DropdownItem>
+								)}
 							</S.DropdownMenu>
 						)}
 					</S.DropdownContainer>

--- a/src/pages/TutorPage/Dashboard/hooks/useDashboard.ts
+++ b/src/pages/TutorPage/Dashboard/hooks/useDashboard.ts
@@ -76,6 +76,7 @@ export function useDashboard() {
 		[],
 	);
 	const [showCopyModal, setShowCopyModal] = useState(false);
+	const [isCopyingSection, setIsCopyingSection] = useState(false);
 	const [copyFormData, setCopyFormData] =
 		useState<DashboardCopyFormData>(initialCopyFormData);
 	const [sourceNotices, setSourceNotices] = useState<DashboardNotice[]>([]);
@@ -165,7 +166,7 @@ export function useDashboard() {
 			alert("수업이 성공적으로 생성되었습니다!");
 			setShowCreateModal(false);
 			setFormData(initialFormData);
-			fetchSections();
+			await fetchSections();
 		} catch (err: unknown) {
 			console.error("수업 생성 실패:", err);
 			alert((err as Error).message || "수업 생성에 실패했습니다.");
@@ -411,15 +412,16 @@ export function useDashboard() {
 	};
 
 	const handleCopySection = async () => {
+		if (!copyFormData.sourceSectionId) {
+			alert("복사할 수업을 선택해주세요.");
+			return;
+		}
+		if (!copyFormData.courseTitle) {
+			alert("새 수업 제목을 입력해주세요.");
+			return;
+		}
+		setIsCopyingSection(true);
 		try {
-			if (!copyFormData.sourceSectionId) {
-				alert("복사할 수업을 선택해주세요.");
-				return;
-			}
-			if (!copyFormData.courseTitle) {
-				alert("새 수업 제목을 입력해주세요.");
-				return;
-			}
 			const response = await APIService.copySection(
 				Number.parseInt(copyFormData.sourceSectionId),
 				null,
@@ -454,6 +456,8 @@ export function useDashboard() {
 		} catch (err: unknown) {
 			console.error("수업 복사 실패:", err);
 			alert((err as Error).message || "수업 복사에 실패했습니다.");
+		} finally {
+			setIsCopyingSection(false);
 		}
 	};
 
@@ -505,6 +509,7 @@ export function useDashboard() {
 		availableCourses,
 		showCopyModal,
 		setShowCopyModal,
+		isCopyingSection,
 		copyFormData,
 		setCopyFormData,
 		sourceNotices,

--- a/src/pages/TutorPage/Dashboard/index.tsx
+++ b/src/pages/TutorPage/Dashboard/index.tsx
@@ -1,5 +1,7 @@
 import type { FC } from "react";
+import { createPortal } from "react-dom";
 import TutorLayout from "../../../layouts/TutorLayout";
+import LoadingSpinner from "../../../components/UI/LoadingSpinner";
 import { useDashboard } from "./hooks/useDashboard";
 import * as S from "./styles";
 import DashboardHeader from "./components/DashboardHeader";
@@ -17,6 +19,7 @@ const CourseManagement: FC = () => {
 		setShowCreateModal,
 		showCopyModal,
 		setShowCopyModal,
+		isCopyingSection,
 		copyStep,
 		setCopyStep,
 		editingNoticeId,
@@ -86,6 +89,32 @@ const CourseManagement: FC = () => {
 
 	return (
 		<TutorLayout>
+			{isCopyingSection &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="수업 복사 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			{loading ? (
 				<S.LoadingContainer>
 					<S.LoadingSpinner />
@@ -96,6 +125,10 @@ const CourseManagement: FC = () => {
 					<DashboardHeader
 						totalCount={sections.length}
 						displayCount={filteredSections.length}
+						canCopySection={sections.some(
+							(s) =>
+								s.roleInSection === "ADMIN" || s.roleInSection === "INSTRUCTOR",
+						)}
 						onCopy={() => setShowCopyModal(true)}
 						onCreate={() => setShowCreateModal(true)}
 					/>
@@ -129,6 +162,7 @@ const CourseManagement: FC = () => {
 					<CopySectionModal
 						isOpen={showCopyModal}
 						onClose={closeCopyModal}
+						loading={isCopyingSection}
 						copyStep={copyStep}
 						setCopyStep={setCopyStep}
 						copyFormData={copyFormData}

--- a/src/pages/TutorPage/Dashboard/types.ts
+++ b/src/pages/TutorPage/Dashboard/types.ts
@@ -29,6 +29,8 @@ export interface DashboardSection {
 	active: boolean;
 	createdAt: string;
 	instructorName?: string;
+	/** 이 수업에서의 내 역할: INSTRUCTOR(강사) / ADMIN / TUTOR(조회·일부만) */
+	roleInSection?: string;
 }
 
 export interface DashboardFormData {

--- a/src/pages/TutorPage/Notices/NoticeCreatePage/index.tsx
+++ b/src/pages/TutorPage/Notices/NoticeCreatePage/index.tsx
@@ -1,5 +1,7 @@
 import type { FC } from "react";
+import { createPortal } from "react-dom";
 import TutorLayout from "../../../../layouts/TutorLayout";
+import LoadingSpinner from "../../../../components/UI/LoadingSpinner";
 import { useNoticeCreate } from "./hooks/useNoticeCreate";
 import * as S from "./styles";
 import NoticeCreateForm from "./components/NoticeCreateForm";
@@ -17,6 +19,32 @@ const NoticeCreatePage: FC = () => {
 
 	return (
 		<TutorLayout selectedSection={currentSection}>
+			{loading &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="공지사항 작성 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Page>
 				<S.Header>
 					<S.BackButton onClick={handleBack}>← 뒤로가기</S.BackButton>

--- a/src/pages/TutorPage/Notices/NoticeEditPage/index.tsx
+++ b/src/pages/TutorPage/Notices/NoticeEditPage/index.tsx
@@ -1,5 +1,7 @@
 import type { FC } from "react";
+import { createPortal } from "react-dom";
 import TutorLayout from "../../../../layouts/TutorLayout";
+import LoadingSpinner from "../../../../components/UI/LoadingSpinner";
 import { useNoticeEdit } from "./hooks/useNoticeEdit";
 import * as S from "../NoticeCreatePage/styles";
 import NoticeEditForm from "./components/NoticeEditForm";
@@ -28,6 +30,32 @@ const NoticeEditPage: FC = () => {
 
 	return (
 		<TutorLayout selectedSection={currentSection}>
+			{saving &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="공지사항 수정 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Page>
 				<S.Header>
 					<S.BackButton onClick={handleBack}>← 뒤로가기</S.BackButton>

--- a/src/pages/TutorPage/Problems/ProblemCreate/components/ProblemCreateView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemCreate/components/ProblemCreateView.tsx
@@ -1,6 +1,8 @@
 import type React from "react";
+import { createPortal } from "react-dom";
 import { FaPalette, FaHighlighter } from "react-icons/fa";
 import TutorLayout from "../../../../../layouts/TutorLayout";
+import LoadingSpinner from "../../../../../components/UI/LoadingSpinner";
 import * as S from "../styles";
 import ProblemPreview from "./ProblemPreview";
 import type { ProblemCreateHookReturn } from "../hooks/useProblemCreate";
@@ -8,6 +10,32 @@ import type { ProblemCreateHookReturn } from "../hooks/useProblemCreate";
 export default function ProblemCreateView(d: ProblemCreateHookReturn) {
 	return (
 		<TutorLayout>
+			{d.loading &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="문제 생성 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Container>
 				<S.PageHeader>
 					<S.PageTitle>새 문제 만들기</S.PageTitle>
@@ -82,7 +110,7 @@ export default function ProblemCreateView(d: ProblemCreateHookReturn) {
 
 							<S.FormRow>
 								<S.FormSection>
-									<S.Label>시간 제한 (초)</S.Label>
+									<S.Label>시간 제한 (초) *</S.Label>
 									<S.Input
 										type="number"
 										name="timeLimit"
@@ -94,7 +122,7 @@ export default function ProblemCreateView(d: ProblemCreateHookReturn) {
 									/>
 								</S.FormSection>
 								<S.FormSection>
-									<S.Label>메모리 제한 (MB)</S.Label>
+									<S.Label>메모리 제한 (MB) *</S.Label>
 									<S.Input
 										type="number"
 										name="memoryLimit"
@@ -137,7 +165,7 @@ export default function ProblemCreateView(d: ProblemCreateHookReturn) {
 									<S.HelpText>
 										{d.loading
 											? "ZIP 파일 내용을 분석 중입니다..."
-											: "문제 ZIP 파일이 있다면 업로드하세요. 자동으로 내용이 채워집니다."}
+											: "문제 ZIP 파일이 있다면 업로드하세요. 자동으로 문제 설명, 문제 제목이 채워집니다."}
 									</S.HelpText>
 								</S.FileUploadWrapper>
 							</S.FormSection>

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
@@ -1,4 +1,6 @@
+import { createPortal } from "react-dom";
 import TutorLayout from "../../../../../layouts/TutorLayout";
+import LoadingSpinner from "../../../../../components/UI/LoadingSpinner";
 import type { ProblemEditHookReturn } from "../hooks/useProblemEdit";
 import * as S from "../styles";
 import ProblemEditBanners from "./ProblemEditBanners";
@@ -26,6 +28,32 @@ export default function ProblemEditView(d: ProblemEditHookReturn) {
 
 	return (
 		<TutorLayout>
+			{d.submitting &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="문제 수정 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.ProblemEditGlobalStyle />
 			<S.Container className="problem-edit">
 				<S.PageHeader>

--- a/src/pages/TutorPage/Problems/ProblemManagement/components/ProblemManagementView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemManagement/components/ProblemManagementView.tsx
@@ -35,7 +35,9 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 						</S.TitleStats>
 					</S.TitleLeft>
 					<S.TitleRight>
-						<S.CreateButton onClick={() => d.navigate("/tutor/problems/create")}>
+						<S.CreateButton
+							onClick={() => d.navigate("/tutor/problems/create")}
+						>
 							+ 새 문제 만들기
 						</S.CreateButton>
 					</S.TitleRight>
@@ -184,20 +186,18 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 															>
 																{problem.title}
 															</S.TitleText>
-															{problem.isUsed && (
-																<S.UsageBadge
-																	title={`${problem.assignmentCount || 0}개 과제에서 사용 중`}
-																>
-																	사용 중
-																	{problem.assignmentCount &&
-																		problem.assignmentCount > 0 && (
-																			<S.UsageCount>
-																				{" "}
-																				({problem.assignmentCount})
-																			</S.UsageCount>
-																		)}
-																</S.UsageBadge>
-															)}
+															{problem.isUsed &&
+																(problem.assignmentCount ?? 0) > 0 && (
+																	<S.UsageBadge
+																		title={`${problem.assignmentCount}개 과제에서 사용 중`}
+																	>
+																		사용 중
+																		<S.UsageCount>
+																			{" "}
+																			({problem.assignmentCount})
+																		</S.UsageCount>
+																	</S.UsageBadge>
+																)}
 														</S.TitleRow>
 														{d.getProblemTags(problem).length > 0 && (
 															<S.Tags>
@@ -297,17 +297,11 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 
 				{/* 문제 설명 모달 */}
 				{d.showProblemModal && d.selectedProblem && (
-					<S.ModalOverlay
-						onClick={d.closeProblemModal}
-					>
+					<S.ModalOverlay onClick={d.closeProblemModal}>
 						<S.ModalContent $large onClick={(e) => e.stopPropagation()}>
 							<S.ModalHeader>
 								<h2>{d.selectedProblem.title}</h2>
-								<S.ModalClose
-									onClick={d.closeProblemModal}
-								>
-									×
-								</S.ModalClose>
+								<S.ModalClose onClick={d.closeProblemModal}>×</S.ModalClose>
 							</S.ModalHeader>
 							<S.ModalBody>
 								<S.DescriptionContent>
@@ -362,9 +356,7 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 
 				{/* 삭제 확인 모달 */}
 				{d.showDeleteModal && d.problemToDelete && (
-					<S.ModalOverlay
-						onClick={d.closeDeleteModal}
-					>
+					<S.ModalOverlay onClick={d.closeDeleteModal}>
 						<S.ModalContent onClick={(e) => e.stopPropagation()}>
 							<S.ModalHeader>
 								<h2>문제 삭제 확인</h2>
@@ -400,16 +392,11 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 
 				{/* 복사 모달 */}
 				{d.showCopyModal && d.problemToCopy && (
-					<S.ModalOverlay
-						onClick={d.closeCopyModal}
-					>
+					<S.ModalOverlay onClick={d.closeCopyModal}>
 						<S.ModalContent onClick={(e) => e.stopPropagation()}>
 							<S.ModalHeader>
 								<h2>문제 복사</h2>
-								<S.ModalClose
-									onClick={d.closeCopyModal}
-									disabled={d.isCopying}
-								>
+								<S.ModalClose onClick={d.closeCopyModal} disabled={d.isCopying}>
 									×
 								</S.ModalClose>
 							</S.ModalHeader>
@@ -429,10 +416,7 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 								</S.FormGroup>
 							</S.ModalBody>
 							<S.ModalFooter>
-								<S.BtnCancel
-									onClick={d.closeCopyModal}
-									disabled={d.isCopying}
-								>
+								<S.BtnCancel onClick={d.closeCopyModal} disabled={d.isCopying}>
 									취소
 								</S.BtnCancel>
 								<S.BtnSubmit
@@ -448,9 +432,7 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 
 				{/* 사용 현황 모달 */}
 				{d.showUsageModal && d.problemForUsage && (
-					<S.ModalOverlay
-						onClick={d.closeUsageModal}
-					>
+					<S.ModalOverlay onClick={d.closeUsageModal}>
 						<S.ModalContent $large onClick={(e) => e.stopPropagation()}>
 							<S.ModalHeader>
 								<h2>문제 사용 현황</h2>
@@ -561,7 +543,9 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 																				fontSize: "14px",
 																			}}
 																		>
-																			{d.formatDateTime(usage.assignmentEndDate)}
+																			{d.formatDateTime(
+																				usage.assignmentEndDate,
+																			)}
 																		</td>
 																	</tr>
 																))}
@@ -574,7 +558,9 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 										{d.problemUsage.problemSets &&
 											d.problemUsage.problemSets.length > 0 && (
 												<S.UsageSection>
-													<h3>문제집 ({d.problemUsage.problemSets.length}개)</h3>
+													<h3>
+														문제집 ({d.problemUsage.problemSets.length}개)
+													</h3>
 													<S.UsageTableWrapper>
 														<S.UsageTable>
 															<thead>
@@ -704,7 +690,7 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 							</S.ModalBody>
 							<S.ModalFooter>
 								<S.BtnCancel
-onClick={d.closeUsageModal}
+									onClick={d.closeUsageModal}
 									disabled={d.loadingUsage}
 								>
 									닫기

--- a/src/pages/TutorPage/Problems/ProblemSetEdit/components/ProblemSetEditView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemSetEdit/components/ProblemSetEditView.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import EmptyState from "../../../../../components/UI/EmptyState";
 import Alert from "../../../../../components/UI/Alert";
 import LoadingSpinner from "../../../../../components/UI/LoadingSpinner";
@@ -37,6 +38,32 @@ export default function ProblemSetEditView(d: ProblemSetEditHookReturn) {
 
 	return (
 		<TutorLayout>
+			{d.isAdding &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="문제 추가 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Container>
 				{d.alertMessage && (
 					<Alert

--- a/src/pages/TutorPage/Problems/ProblemSetManagement/components/ProblemSetManagementView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemSetManagement/components/ProblemSetManagementView.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from "react-dom";
 import EmptyState from "../../../../../components/UI/EmptyState";
 import LoadingSpinner from "../../../../../components/UI/LoadingSpinner";
 import TutorLayout from "../../../../../layouts/TutorLayout";
@@ -17,6 +18,32 @@ export default function ProblemSetManagementView(
 
 	return (
 		<TutorLayout>
+			{d.isCreating &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.35)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 10000,
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "1.5rem 2rem",
+								borderRadius: "12px",
+								boxShadow: "0 4px 20px rgba(0,0,0,0.15)",
+							}}
+						>
+							<LoadingSpinner message="문제집 생성 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
 			<S.Container>
 				<S.TitleHeader>
 					<S.TitleLeft>

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -500,7 +500,7 @@ class APIService {
 	}
 
 	async getInstructorDashboard(): Promise<any> {
-		return await this.request("/user/dashboard");
+		return await this.request("/user/dashboard?instructorOnly=true");
 	}
 
 	async getInstructorStudents(): Promise<any> {


### PR DESCRIPTION
코딩 테스트 수정 시 로딩 표시
만들기/수정하기 전반 로딩 표시
수업 링크 복사 버튼 추가
기존 수업 복사 시 로딩 표시
튜터는 기존 수업 복사 버튼 비노출

## #️⃣연관된 이슈

> #108 
---

### ISSUE 1: 문제 추가 모달 – 복사본 제목 기준 중복 제거 제거

**관련 페이지/경로**
- 튜터 > 과제 관리 (`/tutor/assignments/section/:sectionId`)
- 특정 과제에서 「문제 추가」 클릭 시 뜨는 **문제 선택 모달**

**했던 일**
- 과제에 문제를 추가할 때, “같은 기준 제목(복사본 제거)”으로 한 문제만 보이던 필터를 없애고, **모든 문제를 원래 제목 그대로** 리스트에 보이도록 수정.

**수정 파일 (1개)**

| 파일 | 수정 내용 |
|------|-----------|
| `Handongjudge_FE/src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts` | ① 상단에서 `removeCopyLabel` import 제거.<br>② `filteredProblems` 계산 시, 검색어·이미 과제에 포함된 문제(id·제목)만 걸러주는 `.filter()` 한 개만 유지.<br>③ “같은 기준 제목(복사본 제거)의 문제는 하나만 표시”하던 두 번째 `.filter()` 전체 삭제 (그 안에서 `removeCopyLabel`로 기준 제목 비교하던 로직 제거). |

**결과**
- 문제 추가 모달에서 “A (복사본)”, “A (복사본 2)” 등이 각각 따로 보이고, 동일 제목이어도 전부 선택 가능.

---

### ISSUE 2: 코딩 테스트 수정 시 로딩 표시

**관련 페이지/경로**
- 튜터 > 코딩 테스트 관리 (`/tutor/coding-tests/section/:sectionId`)
- 목록에서 **수정** 클릭 시 뜨는 **코딩 테스트 수정 모달**

**했던 일**
- 수정 모달에서 「수정」 버튼 클릭 후 API 완료까지 **로딩 오버레이**를 띄우고, 버튼을 비활성화·문구를 “수정 중...”으로 변경.

**수정 파일 (2개)**

| 파일 | 수정 내용 |
|------|-----------|
| `Handongjudge_FE/src/pages/TutorPage/CodingTests/CodingTestManagement/hooks/useCodingTestManagement.ts` | ① `isSubmittingEdit` 상태 추가 (`useState(false)`).<br>② `handleSubmitEdit` 내부: 유효성 통과 후 맨 앞에서 `setIsSubmittingEdit(true)`, `catch` 다음에 `finally` 블록 추가하고 그 안에서 `setIsSubmittingEdit(false)` 호출.<br>③ 반환 객체에 `isSubmittingEdit` 포함. |
| `Handongjudge_FE/src/pages/TutorPage/CodingTests/CodingTestManagement/components/CodingTestManagementView.tsx` | ① 상단에 `createPortal` import 추가.<br>② 메인 return 안, `TutorLayout` 직후에 `d.isSubmittingEdit`일 때만 `createPortal`로 전체 화면 반투명 오버레이 + 흰 카드 + `<LoadingSpinner message="코딩 테스트 수정 중..." />` 렌더 (포탈은 `document.body`).<br>③ 수정 모달 푸터의 제출 버튼: `disabled={d.isSubmittingEdit}`, 자식 텍스트를 `d.isSubmittingEdit ? "수정 중..." : "수정"` 으로 변경. |

**결과**
- 수정 클릭 시 “코딩 테스트 수정 중...” 로딩 창이 뜨고, 수정 버튼이 비활성·“수정 중...”으로 바뀜.

---

### ISSUE 3: 만들기/수정하기 전반 로딩 표시

**목적**
- 만들기·수정하기 제출 중에는 **공통 로딩 오버레이** + 제출/취소 버튼 비활성 및 문구 변경을 모든 해당 화면에 적용.

**3-1. 코딩 테스트 생성**

| 항목 | 내용 |
|------|------|
| 페이지/경로 | 튜터 > 코딩 테스트 관리 > **새 코딩 테스트 만들기** 모달 |
| 파일 | `useCodingTestManagement.ts`, `CodingTestManagementView.tsx` |
| 훅 수정 | `isSubmittingCreate` 상태 추가. `handleSubmitCreate` 시작 시 `setIsSubmittingCreate(true)`, `finally`에서 `setIsSubmittingCreate(false)`. 반환에 `isSubmittingCreate` 추가. |
| 뷰 수정 | 기존 수정 로딩 오버레이 조건을 `(d.isSubmittingCreate \|\| d.isSubmittingEdit)` 로 확장하고, 메시지를 `isSubmittingCreate ? "코딩 테스트 생성 중..." : "코딩 테스트 수정 중..."` 로 분기. 생성 모달 푸터의 「생성」 버튼에 `disabled={d.isSubmittingCreate}`, 문구 `d.isSubmittingCreate ? "생성 중..." : "생성"` 적용. |

**3-2. 과제 관리 – 과제 생성/수정 모달**

| 항목 | 내용 |
|------|------|
| 페이지/경로 | 튜터 > 과제 관리 (`/tutor/assignments/section/:sectionId`) > **새 과제 생성** 모달 / **과제 수정** 모달 |
| 파일 | `AssignmentManagement/hooks/useAssignmentManagement.ts`, `AssignmentManagement/index.tsx`, `AssignmentModals/AssignmentAddModal.tsx`, `AssignmentModals/AssignmentEditModal.tsx` |
| 훅 수정 | `isSubmittingAdd`, `isSubmittingEdit` 추가. `handleSubmitAdd` / `handleSubmitEdit` 내부에서 유효성 통과 후 각각 `setIsSubmittingAdd(true)` / `setIsSubmittingEdit(true)`, `finally`에서 false. 반환에 두 값 포함. |
| index 수정 | 기존 “문제 추가 중...” 오버레이 조건을 `(d.isAddingProblems \|\| d.isSubmittingAdd \|\| d.isSubmittingEdit)` 로 확장. 메시지를 `isAddingProblems ? "문제 추가 중..." : isSubmittingAdd ? "과제 생성 중..." : "과제 수정 중..."` 로 분기. `AssignmentAddModal`/`AssignmentEditModal`에 `loading={d.isSubmittingAdd}` / `loading={d.isSubmittingEdit}` 전달. |
| AddModal 수정 | props에 `loading?: boolean` 추가 (기본 false). 푸터의 취소·과제 생성 버튼에 `disabled={loading}`. 생성 버튼 문구 `loading ? "생성 중..." : "과제 생성"`. |
| EditModal 수정 | 동일하게 `loading` prop 추가, 취소·수정 완료 버튼 `disabled={loading}`, 수정 버튼 문구 `loading ? "수정 중..." : "수정 완료"`. |

**3-3. 공지 작성/수정 페이지**

| 항목 | 내용 |
|------|------|
| 페이지/경로 | 튜터 > 공지사항 관리 > **새 공지사항 작성** (`/tutor/notices/section/:sectionId/create`), **공지사항 수정** (`/tutor/notices/section/:sectionId/:noticeId/edit`) |
| 파일 | `NoticeCreatePage/index.tsx`, `NoticeEditPage/index.tsx` |
| Create 수정 | `createPortal`, `LoadingSpinner` import. `TutorLayout` 직후, `loading`이 true일 때 “공지사항 작성 중...” 로딩 오버레이(동일 스타일)를 `document.body`에 포탈. |
| Edit 수정 | `createPortal`, `LoadingSpinner` import. 초기 로딩 분기 다음, 메인 return 안 `TutorLayout` 직후에 `saving`이 true일 때 “공지사항 수정 중...” 오버레이 포탈. |

**3-4. 과제 생성/수정 (별도 페이지)**

| 항목 | 내용 |
|------|------|
| 페이지/경로 | **새 과제 만들기** (`/tutor/assignments/section/:sectionId/create`), **과제 수정** (`/tutor/assignments/section/:sectionId/:assignmentId/edit`) |
| 파일 | `AssignmentCreatePage/index.tsx`, `AssignmentEditPage/index.tsx` |
| Create 수정 | `createPortal`, `LoadingSpinner` import. `loading`일 때 “과제 생성 중...” 오버레이 포탈. |
| Edit 수정 | `createPortal` import. `submitting`일 때 “과제 수정 중...” 오버레이 포탈. |

**3-5. 문제 생성/수정**

| 항목 | 내용 |
|------|------|
| 페이지/경로 | **새 문제 만들기** (`/tutor/problems/create`), **문제 수정** (`/tutor/problems/:problemId/edit`) |
| 파일 | `ProblemCreate/components/ProblemCreateView.tsx`, `ProblemEdit/components/ProblemEditView.tsx` |
| Create 수정 | `createPortal`, `LoadingSpinner` import. 메인 return 맨 앞에서 `d.loading`일 때 “문제 생성 중...” 오버레이 포탈. |
| Edit 수정 | `createPortal`, `LoadingSpinner` import. `getBackNavigation()` 호출 다음, 메인 return에서 `d.submitting`일 때 “문제 수정 중...” 오버레이 포탈. |

**3-6. 문제집 생성/문제 추가**

| 항목 | 내용 |
|------|------|
| 페이지/경로 | 튜터 > 문제 관리 > 문제집 관리 (`/tutor/problems/sets`) 의 **새 문제집 만들기** 모달 / 문제집 수정 페이지에서 **문제 추가** 모달 |
| 파일 | `ProblemSetManagement/components/ProblemSetManagementView.tsx`, `ProblemSetEdit/components/ProblemSetEditView.tsx` |
| Management 수정 | `createPortal` import. `d.loading` early return 다음, 메인 return의 `TutorLayout` 직후에 `d.isCreating`일 때 “문제집 생성 중...” 오버레이 포탈. |
| Edit 수정 | `createPortal` import. `loading` early return 다음, 메인 return의 `TutorLayout` 직후에 `d.isAdding`일 때 “문제 추가 중...” 오버레이 포탈. |

**공통 오버레이 스타일**
- `position: fixed`, `inset: 0`, `backgroundColor: "rgba(0,0,0,0.35)"`, `zIndex: 10000`, 중앙에 흰 박스 + `<LoadingSpinner message="..." />`, `createPortal(..., document.body)`.

---

### ISSUE 4: 수업 링크 복사 버튼 추가

**관련 페이지/경로**
- 튜터 레이아웃이 쓰이는 **모든 튜터 페이지** (과제 관리, 공지, 코딩 테스트, 수강생 관리 등)
- 왼쪽 사이드바 **수업 관리** 블록 (수업 선택 카드 아래, “대시보드”, “과제 관리” 등 메뉴 위)

**했던 일**
- “수업 관리” 섹션에 **수업 링크 복사** 버튼을 넣고, 클릭 시 `{origin}/tutor` 주소를 클립보드에 복사.

**수정 파일 (2개)**

| 파일 | 수정 내용 |
|------|-----------|
| `Handongjudge_FE/src/layouts/TutorLayout/index.tsx` | ① 아이콘 import에 `FaLink` 추가.<br>② `handleCopyTutorLink` 함수 추가: `const tutorLink = \`${window.location.origin}/tutor\``, `navigator.clipboard.writeText(tutorLink)`, 성공 시 "수업 링크가 복사되었습니다.", 실패 시 "링크 복사에 실패했습니다." alert.<br>③ “수업 관리” `SidebarSectionTitle` 바로 아래에 `SidebarLinkCopyBtn` 버튼 추가: `$collapsed={sidebarCollapsed}`, `onClick={handleCopyTutorLink}`, `title={sidebarCollapsed ? "수업 링크 복사" : ""}`, 아이콘 `FaLink`, 접히지 않았을 때 텍스트 "수업 링크 복사". |
| `Handongjudge_FE/src/layouts/TutorLayout/styles.ts` | `SidebarLinkCopyBtn` 스타일 컴포넌트 추가: 버튼 형태, 사이드바 메뉴와 비슷한 패딩/간격, `$collapsed`에 따라 너비·패딩, hover 시 배경·색상 변경, 아이콘 영역 유지. |

**결과**
- 수업을 선택한 뒤 왼쪽 “수업 관리” 아래에 “수업 링크 복사” 버튼이 보이고, 클릭 시 현재 도메인 기준 `/tutor` URL이 복사됨.

---

### ISSUE 5: 기존 수업 복사 시 로딩 표시

**관련 페이지/경로**
- 튜터 > **수업 관리(대시보드)** (`/tutor` 또는 `/tutor/dashboard` 등)
- 상단 「기존 수업 복사」 클릭 시 뜨는 **기존 수업 복사** 모달 (단계별: 수업 선택 → 공지/과제 선택 → 확인 → 복사하기)

**했던 일**
- 복사하기 클릭 후 API 완료까지 로딩 오버레이를 띄우고, 모달 내 이전/취소/다음·복사하기 버튼을 비활성화하며 “복사하기” 문구를 “복사 중...”으로 변경.

**수정 파일 (3개)**

| 파일 | 수정 내용 |
|------|-----------|
| `Handongjudge_FE/src/pages/TutorPage/Dashboard/hooks/useDashboard.ts` | ① `isCopyingSection` 상태 추가 (`useState(false)`).<br>② `handleCopySection`: 유효성 검사 후 `setIsCopyingSection(true)`, try/catch 뒤 `finally`에서 `setIsCopyingSection(false)`.<br>③ 반환 객체에 `isCopyingSection` 추가. |
| `Handongjudge_FE/src/pages/TutorPage/Dashboard/index.tsx` | ① `createPortal`, `LoadingSpinner` import.<br>② `isCopyingSection` destructure.<br>③ `TutorLayout` 직후, `loading` 분기 전에 `isCopyingSection`일 때 “수업 복사 중...” 로딩 오버레이 포탈.<br>④ `CopySectionModal`에 `loading={isCopyingSection}` prop 전달. |
| `Handongjudge_FE/src/pages/TutorPage/Dashboard/components/CopySectionModal.tsx` | ① props 인터페이스에 `loading?: boolean` 추가.<br>② destructure에 `loading = false` 추가.<br>③ 푸터: 이전 버튼 `disabled={loading}`, 취소 버튼 `disabled={loading}`, 다음 버튼 `disabled={loading}`, 복사하기 버튼 `disabled={loading}` 및 문구 `loading ? "복사 중..." : "복사하기"`. |

**결과**
- 4단계에서 복사하기 클릭 시 “수업 복사 중...” 오버레이가 뜨고, 모달 버튼들이 비활성·“복사 중...”으로 표시됨.

---

### ISSUE 6: 튜터는 기존 수업 복사 버튼 비노출

**관련 페이지/경로**
- 튜터 > **수업 관리(대시보드)** (`/tutor` 등) 상단 헤더 (총 N개 분반, 표시 N개 옆의 버튼 영역)

**했던 일**
- ADMIN 또는 INSTRUCTOR인 수업이 **하나라도 있을 때만** 「기존 수업 복사」 버튼을 보이게 하고, 전부 TUTOR만 있으면 버튼을 숨김.

**수정 파일 (2개)**

| 파일 | 수정 내용 |
|------|-----------|
| `Handongjudge_FE/src/pages/TutorPage/Dashboard/components/DashboardHeader.tsx` | ① props에 `canCopySection: boolean` 추가 (주석: ADMIN인 수업이 하나라도 있을 때만 true).<br>② destructure에 `canCopySection` 추가.<br>③ 「기존 수업 복사」 버튼을 `{canCopySection && ( ... <S.CopyButton>기존 수업 복사</S.CopyButton> )}` 로 감싸서 조건부 렌더. |
| `Handongjudge_FE/src/pages/TutorPage/Dashboard/index.tsx` | ① `DashboardHeader`에 `canCopySection={sections.some(s => s.roleInSection === "ADMIN" \|\| s.roleInSection === "INSTRUCTOR")}` 전달. |

**결과**
- 모든 관리 수업이 TUTOR만인 사용자(순수 조교)는 “기존 수업 복사” 버튼이 안 보임. ADMIN/INSTRUCTOR인 수업이 하나라도 있으면 버튼이 보임 (실제 복사는 백엔드에서 ADMIN만 허용).