### PR TITLE
알림 페이지 - 과제 알림 문구 및 스타일 통일

### DIFF
--- a/src/pages/Course/Notifications/CourseNotificationsPage/components/CourseNotificationsPageView.tsx
+++ b/src/pages/Course/Notifications/CourseNotificationsPage/components/CourseNotificationsPageView.tsx
@@ -60,6 +60,7 @@ export default function CourseNotificationsPageView(
 							<S.StatItem>안 읽음 {d.stats.unread}</S.StatItem>
 							<S.StatItem>공지 {d.stats.notices}</S.StatItem>
 							<S.StatItem>과제 {d.stats.assignments}</S.StatItem>
+							<S.StatItem>커뮤니티 {d.stats.community}</S.StatItem>
 						</S.NotificationsStats>
 						<S.SortButton onClick={d.handleSortToggle}>
 							<span>최신순</span>
@@ -78,9 +79,7 @@ export default function CourseNotificationsPageView(
 									key={notification.id}
 									$isNew={notification.isNew}
 									$type={notification.type}
-									onClick={() =>
-										d.handleNotificationClick(notification)
-									}
+									onClick={() => d.handleNotificationClick(notification)}
 								>
 									<S.NotificationContent>
 										<S.NotificationTag

--- a/src/pages/Course/Notifications/CourseNotificationsPage/hooks/useCourseNotificationsPage.ts
+++ b/src/pages/Course/Notifications/CourseNotificationsPage/hooks/useCourseNotificationsPage.ts
@@ -30,6 +30,7 @@ export function useCourseNotificationsPage() {
 		unread: 0,
 		notices: 0,
 		assignments: 0,
+		community: 0,
 	});
 
 	const fetchData = useCallback(async () => {
@@ -48,8 +49,7 @@ export function useCourseNotificationsPage() {
 				0,
 				200,
 			);
-			const notificationsList =
-				notificationsResponse.data?.content ?? [];
+			const notificationsList = notificationsResponse.data?.content ?? [];
 
 			const notificationList: Notification[] = notificationsList.map(
 				(notif: Record<string, unknown>) => {
@@ -59,22 +59,28 @@ export function useCourseNotificationsPage() {
 						"other";
 
 					switch (notif.type) {
-						case "NOTICE_CREATED":
-							title = (notif.noticeTitle as string) || "공지사항";
+						case "NOTICE_CREATED": {
+							const noticeTitle = (notif.noticeTitle as string) || "공지사항";
+							title = `교수님이 "${noticeTitle}" 공지를 올리셨습니다`;
 							link = notif.noticeId
 								? `/sections/${sectionId}/course-notices/${notif.noticeId}`
 								: null;
 							displayType = "notice";
 							break;
-						case "ASSIGNMENT_CREATED":
-							title = (notif.assignmentTitle as string) || "과제";
+						}
+						case "ASSIGNMENT_CREATED": {
+							const assignmentTitle =
+								(notif.assignmentTitle as string) || "과제";
+							title = `교수님이 ${assignmentTitle} 새 과제를 올리셨습니다!`;
 							link = notif.assignmentId
 								? `/sections/${sectionId}/course-assignments?assignmentId=${notif.assignmentId}`
 								: null;
 							displayType = "assignment";
 							break;
+						}
 						case "QUESTION_COMMENT":
-							title = (notif.message as string) || "내 질문에 댓글이 달렸습니다";
+							title =
+								(notif.message as string) || "내 질문에 댓글이 달렸습니다";
 							link = notif.questionId
 								? `/sections/${sectionId}/community/${notif.questionId}`
 								: null;
@@ -147,12 +153,16 @@ export function useCourseNotificationsPage() {
 			const assignmentCount = notificationList.filter(
 				(n) => n.type === "assignment",
 			).length;
+			const communityCount = notificationList.filter(
+				(n) => n.type === "community",
+			).length;
 
 			setStats({
 				total: notificationList.length,
 				unread: unreadCount,
 				notices: noticeCount,
 				assignments: assignmentCount,
+				community: communityCount,
 			});
 		} catch (error) {
 			console.error("데이터 로딩 실패:", error);

--- a/src/pages/Course/Notifications/CourseNotificationsPage/styles.ts
+++ b/src/pages/Course/Notifications/CourseNotificationsPage/styles.ts
@@ -131,8 +131,8 @@ export const NotificationsList = styled.div`
 `;
 
 export const NotificationCard = styled.div<{
-  $isNew: boolean;
-  $type: "notice" | "assignment" | "community" | "other";
+	$isNew: boolean;
+	$type: "notice" | "assignment" | "community" | "other";
 }>`
   display: flex;
   align-items: center;
@@ -143,12 +143,9 @@ export const NotificationCard = styled.div<{
   border: none;
   margin-bottom: 8px;
   background: ${(props) => {
-    if (props.$isNew) {
-      return props.$type === "assignment" ? "#000000" : "#B3BFF5";
-    } else {
-      return props.$type === "assignment" ? "#000000" : "#D9DFF9";
-    }
-  }};
+		if (props.$isNew) return "#B3BFF5";
+		return "#D9DFF9";
+	}};
 
   &:hover {
     opacity: 0.9;
@@ -167,8 +164,8 @@ export const NotificationContent = styled.div`
 `;
 
 export const NotificationTag = styled.span<{
-  $isNew: boolean;
-  $type: "notice" | "assignment" | "community" | "other";
+	$isNew: boolean;
+	$type: "notice" | "assignment" | "community" | "other";
 }>`
   padding: 4px 12px;
   border-radius: 12px;
@@ -184,8 +181,8 @@ export const NotificationTag = styled.span<{
 `;
 
 export const NotificationTitle = styled.span<{
-  $isNew: boolean;
-  $type: "notice" | "assignment" | "community" | "other";
+	$isNew: boolean;
+	$type: "notice" | "assignment" | "community" | "other";
 }>`
   font-size: 14px;
   font-weight: ${(props) => (props.$isNew ? "600" : "500")};
@@ -196,22 +193,19 @@ export const NotificationTitle = styled.span<{
   text-overflow: ellipsis;
   order: 2;
   color: ${(props) => {
-    if (props.$type === "assignment" && props.$isNew) return "#FFFFFF";
-    if (props.$type === "assignment" && !props.$isNew) return "#FFFFFF";
-    if (props.$type === "notice" && !props.$isNew) return "#667EEA";
-    return "#000000";
-  }};
+		if (props.$type === "notice" && !props.$isNew) return "#667EEA";
+		return "#000000";
+	}};
 `;
 
 export const NotificationDate = styled.span<{
-  $isNew: boolean;
-  $type: "notice" | "assignment" | "community" | "other";
+	$isNew: boolean;
+	$type: "notice" | "assignment" | "community" | "other";
 }>`
   color: ${(props) => {
-    if (props.$type === "assignment") return "#CCCCCC";
-    if (props.$type === "notice" && !props.$isNew) return "#667EEA";
-    return "#666666";
-  }};
+		if (props.$type === "notice" && !props.$isNew) return "#667EEA";
+		return "#666666";
+	}};
   font-size: 13px;
   font-weight: 400;
   margin-left: auto;

--- a/src/pages/Course/Notifications/CourseNotificationsPage/types.ts
+++ b/src/pages/Course/Notifications/CourseNotificationsPage/types.ts
@@ -1,24 +1,25 @@
 export interface Notification {
-  id: number;
-  type: "notice" | "assignment" | "community" | "other";
-  originalId: number;
-  title: string;
-  date: string;
-  isNew: boolean;
-  createdAt: string;
-  link: string | null;
-  notificationType: string;
+	id: number;
+	type: "notice" | "assignment" | "community" | "other";
+	originalId: number;
+	title: string;
+	date: string;
+	isNew: boolean;
+	createdAt: string;
+	link: string | null;
+	notificationType: string;
 }
 
 export interface SectionInfo {
-  id: number;
-  courseTitle?: string;
-  courseName?: string;
+	id: number;
+	courseTitle?: string;
+	courseName?: string;
 }
 
 export interface Stats {
-  total: number;
-  unread: number;
-  notices: number;
-  assignments: number;
+	total: number;
+	unread: number;
+	notices: number;
+	assignments: number;
+	community: number;
 }

--- a/src/pages/TutorPage/Notices/NoticeCreatePage/hooks/useNoticeCreate.ts
+++ b/src/pages/TutorPage/Notices/NoticeCreatePage/hooks/useNoticeCreate.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import APIService from "../../../../../services/APIService";
+import { normalizeNoticeContent } from "../../utils/normalizeNoticeContent";
 import type { NoticeFormData, SectionInfo } from "../types";
 
 export function useNoticeCreate() {
@@ -60,7 +61,11 @@ export function useNoticeCreate() {
 			}
 			try {
 				setLoading(true);
-				await APIService.createNotice(formData);
+				const contentToSend = normalizeNoticeContent(formData.content);
+				await APIService.createNotice({
+					...formData,
+					content: contentToSend,
+				});
 				alert("공지사항이 생성되었습니다.");
 				if (sectionId) {
 					navigate(`/tutor/notices/section/${sectionId}`);

--- a/src/pages/TutorPage/Notices/NoticeEditPage/hooks/useNoticeEdit.ts
+++ b/src/pages/TutorPage/Notices/NoticeEditPage/hooks/useNoticeEdit.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import APIService from "../../../../../services/APIService";
+import { normalizeNoticeContent } from "../../utils/normalizeNoticeContent";
 import type { NoticeFormData, SectionInfo } from "../types";
 
 export function useNoticeEdit() {
@@ -106,7 +107,11 @@ export function useNoticeEdit() {
 			}
 			try {
 				setSaving(true);
-				await APIService.updateNotice(noticeId!, formData);
+				const contentToSend = normalizeNoticeContent(formData.content);
+				await APIService.updateNotice(noticeId!, {
+					...formData,
+					content: contentToSend,
+				});
 				alert("공지사항이 수정되었습니다.");
 				if (sectionId) {
 					navigate(`/tutor/notices/section/${sectionId}`);

--- a/src/pages/TutorPage/Notices/utils/normalizeNoticeContent.ts
+++ b/src/pages/TutorPage/Notices/utils/normalizeNoticeContent.ts
@@ -1,0 +1,21 @@
+/**
+ * TipTap 에디터가 반환하는 HTML에서 단일 <p> 래퍼를 제거합니다.
+ * 예: "<p>내용</p>" → "내용", "<p><br></p>" → ""
+ * 여러 단락이나 다른 블록이 있으면 그대로 반환합니다.
+ */
+export function normalizeNoticeContent(html: string): string {
+	const trimmed = html.trim();
+	if (!trimmed) return trimmed;
+
+	const div = document.createElement("div");
+	div.innerHTML = trimmed;
+
+	const children = div.childNodes;
+	if (children.length !== 1) return trimmed;
+
+	const first = children[0];
+	if (first.nodeType !== Node.ELEMENT_NODE) return trimmed;
+	if ((first as Element).tagName !== "P") return trimmed;
+
+	return (first as Element).innerHTML.trim();
+}


### PR DESCRIPTION
#108 

### [FE] 알림 페이지 - 과제 알림 문구 및 스타일 통일

**제목:** 과제 알림 문구 변경 및 커뮤니티 알림과 동일한 카드 스타일 적용

**설명:**  
과제 알림이 "12" 등 ID만 보이던 문제를 개선하고, 커뮤니티 알림과 같은 연한 보라색 카드로 통일.

**수정 파일:**  
- `Handongjudge_FE/src/pages/Course/Notifications/CourseNotificationsPage/hooks/useCourseNotificationsPage.ts`
- `Handongjudge_FE/src/pages/Course/Notifications/CourseNotificationsPage/styles.ts`

**수정 내용:**
- 과제 알림 제목: `교수님이 ${assignmentTitle} 새 과제를 올리셨습니다!` 형식으로 표시
- NotificationCard: 과제 타입도 연한 보라색 배경(`#B3BFF5` / `#D9DFF9`) 사용 (기존 검정 제거)
- NotificationTitle / NotificationDate: 과제 타입 전용 흰색·회색 제거, 커뮤니티와 동일한 텍스트 색 적용

**체크리스트:**
- [ ] 과제 알림 카드가 연한 보라색 배경으로 표시됨
- [ ] 과제 알림 제목이 "교수님이 (과제 제목) 새 과제를 올리셨습니다!" 형태로 표시됨

---

### [FE] 알림 페이지 - 공지 알림 문구 및 커뮤니티 탭 추가

**제목:** 공지 알림 문구 변경 및 알림 통계에 "커뮤니티" 항목 추가

**설명:**  
공지 알림 문구를 통일하고, 알림 상단 탭에 커뮤니티 알림 개수를 표시.

**수정 파일:**  
- `Handongjudge_FE/src/pages/Course/Notifications/CourseNotificationsPage/types.ts`
- `Handongjudge_FE/src/pages/Course/Notifications/CourseNotificationsPage/hooks/useCourseNotificationsPage.ts`
- `Handongjudge_FE/src/pages/Course/Notifications/CourseNotificationsPage/components/CourseNotificationsPageView.tsx`

**수정 내용:**
- 공지 알림 제목: `교수님이 "${noticeTitle}" 공지를 올리셨습니다` 형식으로 표시
- `Stats`에 `community: number` 추가
- 알림 목록 변환 시 `type === "community"` 개수 집계 후 `stats.community`에 설정
- 상단 탭에 `커뮤니티 {d.stats.community}` 항목 추가

**체크리스트:**
- [ ] 공지 알림 제목이 교수님이 "(공지제목)" 공지를 올리셨습니다 형태로 표시됨
- [ ] 알림 탭에 "전체 / 안 읽음 / 공지 / 과제 / 커뮤니티" 순서로 표시되고, 커뮤니티 개수가 올바르게 표시됨

---

### [FE] 공지 작성/수정 시 TipTap `<p>` 래퍼 제거 후 전송

**제목:** 공지 내용 전송 시 에디터 단일 `<p>` 래퍼 제거

**설명:**  
TipTap 에디터가 내용을 `<p>...</p>`로 감싸서 보내는 것을 방지하기 위해, 전송 직전에 단일 `<p>` 래퍼만 제거한 HTML을 서버로 보내도록 수정.

**수정 파일:**  
- `Handongjudge_FE/src/pages/TutorPage/Notices/utils/normalizeNoticeContent.ts` (신규)
- `Handongjudge_FE/src/pages/TutorPage/Notices/NoticeCreatePage/hooks/useNoticeCreate.ts`
- `Handongjudge_FE/src/pages/TutorPage/Notices/NoticeEditPage/hooks/useNoticeEdit.ts`

**수정 내용:**
- `normalizeNoticeContent(html)`: DOM으로 파싱 후 최상위가 단일 `<p>`일 때만 해당 `<p>`의 innerHTML 반환, 그 외는 원문 반환
- 공지 생성: `APIService.createNotice` 호출 전 `content`를 `normalizeNoticeContent(formData.content)`로 치환
- 공지 수정: `APIService.updateNotice` 호출 전 동일하게 `content` 정규화 후 전송

**체크리스트:**
- [ ] 공지 작성 시 단순 한 줄 내용이 `<p>` 없이 저장됨
- [ ] 공지 수정 시에도 동일하게 적용됨
- [ ] 여러 단락/다른 블록이 있는 내용은 기존과 같이 유지됨

---
