### PR TITLE
1. 과제 관리 – 시작일/마감일

### DIFF
--- a/src/pages/Course/Assignments/CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx
@@ -106,8 +106,16 @@ export default function CourseAssignmentsPageView(
 										</S.AccordionHeaderLeft>
 										<S.AccordionHeaderRight>
 											<S.AccordionDeadline>
-												[마감일 | {d.formatDate(assignment.endDate)} 23:59 까지
-												제출]
+												[마감일 |{" "}
+												{(() => {
+													const deadline = d.formatDeadline(
+														assignment.endDate,
+													);
+													return deadline
+														? `${deadline} 까지 제출`
+														: "미설정";
+												})()}
+												]
 											</S.AccordionDeadline>
 											<S.ProgressInfo>
 												<S.MiniProgressBar>

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts
@@ -219,6 +219,19 @@ export function useCourseAssignmentsPage() {
 		return `${year}.${month}.${day}`;
 	}, []);
 
+	/** 마감일·시간을 로컬 기준 "YYYY.MM.DD HH:mm"으로 표시 (API UTC → 로컬 변환) */
+	const formatDeadline = useCallback((dateString: string): string => {
+		if (!dateString?.trim()) return "";
+		const date = new Date(dateString);
+		if (Number.isNaN(date.getTime())) return "";
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, "0");
+		const day = String(date.getDate()).padStart(2, "0");
+		const hours = String(date.getHours()).padStart(2, "0");
+		const minutes = String(date.getMinutes()).padStart(2, "0");
+		return `${year}.${month}.${day} ${hours}:${minutes}`;
+	}, []);
+
 	const handleMenuClick = useCallback(
 		(menuId: string) => {
 			switch (menuId) {
@@ -262,6 +275,7 @@ export function useCourseAssignmentsPage() {
 		fetchAssignmentsData,
 		toggleAssignment,
 		formatDate,
+		formatDeadline,
 		handleMenuClick,
 		handleProblemClick,
 		handleToggleSidebar,

--- a/src/pages/Course/Notices/CourseNoticeDetailPage/hooks/useCourseNoticeDetailPage.ts
+++ b/src/pages/Course/Notices/CourseNoticeDetailPage/hooks/useCourseNoticeDetailPage.ts
@@ -67,10 +67,12 @@ export function useCourseNoticeDetailPage() {
 		}
 	}, [sectionId, noticeId, auth.user, fetchNoticeDetail]);
 
+	/** 공지 작성일: API가 UTC로 저장하므로 날짜만 UTC 기준으로 표시 */
 	const formatDate = useCallback((dateString: string): string => {
 		if (!dateString) return "";
 		const date = new Date(dateString);
-		return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+		if (Number.isNaN(date.getTime())) return "";
+		return `${date.getUTCFullYear()}.${String(date.getUTCMonth() + 1).padStart(2, "0")}.${String(date.getUTCDate()).padStart(2, "0")}`;
 	}, []);
 
 	const handleMenuClick = useCallback(

--- a/src/pages/Course/Notices/CourseNoticesPage/hooks/useCourseNoticesPage.ts
+++ b/src/pages/Course/Notices/CourseNoticesPage/hooks/useCourseNoticesPage.ts
@@ -70,12 +70,14 @@ export function useCourseNoticesPage() {
 		});
 	}, [sortOrder]);
 
+	/** 공지 작성일: API가 UTC로 저장하므로 날짜만 UTC 기준으로 표시 (23일 19:51 UTC → 23일) */
 	const formatDate = useCallback((dateString: string): string => {
 		if (!dateString) return "";
 		const date = new Date(dateString);
-		const year = date.getFullYear();
-		const month = String(date.getMonth() + 1).padStart(2, "0");
-		const day = String(date.getDate()).padStart(2, "0");
+		if (Number.isNaN(date.getTime())) return "";
+		const year = date.getUTCFullYear();
+		const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+		const day = String(date.getUTCDate()).padStart(2, "0");
 		return `${year}.${month}.${day}`;
 	}, []);
 

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/AssignmentAddModal.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/AssignmentAddModal.tsx
@@ -53,6 +53,14 @@ const AssignmentAddModal: React.FC<AssignmentAddModalProps> = ({
 		if (!formData.title?.trim()) errs.title = true;
 		if (!formData.startDate?.trim()) errs.startDate = true;
 		if (!formData.dueDate?.trim()) errs.dueDate = true;
+		if (formData.startDate && formData.dueDate) {
+			const start = new Date(formData.startDate).getTime();
+			const end = new Date(formData.dueDate).getTime();
+			if (end < start) {
+				alert("마감일은 시작일보다 빠를 수 없습니다.");
+				return;
+			}
+		}
 		setErrors(errs);
 		if (Object.keys(errs).length > 0) {
 			return;

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/AssignmentEditModal.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/AssignmentEditModal.tsx
@@ -57,7 +57,20 @@ const AssignmentEditModal: React.FC<AssignmentEditModalProps> = ({
 					<S.ModalCloseButton onClick={onClose}>✕</S.ModalCloseButton>
 				</S.ModalHeader>
 
-				<S.Form onSubmit={onSubmit}>
+				<S.Form
+					onSubmit={(e) => {
+						e.preventDefault();
+						if (formData.startDate && formData.dueDate) {
+							const start = new Date(formData.startDate).getTime();
+							const end = new Date(formData.dueDate).getTime();
+							if (end < start) {
+								alert("마감일은 시작일보다 빠를 수 없습니다.");
+								return;
+							}
+						}
+						onSubmit(e);
+					}}
+				>
 					<S.FormRow>
 						<S.FormGroup>
 							<S.Label htmlFor="edit-title">과제명 *</S.Label>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx
@@ -100,12 +100,20 @@ const AssignmentListView: React.FC<AssignmentListViewProps> = ({
 								<span className="tutor-assignment-meta-item">
 									<span className="tutor-meta-label">마감일</span>
 									<span className="tutor-meta-value">
-										{assignment.dueDate
-											? new Date(assignment.dueDate).toLocaleDateString(
-													"ko-KR",
-													{ month: "short", day: "numeric" },
-												)
-											: "미설정"}
+										{(() => {
+											const raw =
+												assignment.dueDate ??
+												(assignment as { endDate?: string }).endDate;
+											if (!raw?.trim()) return "미설정";
+											const d = new Date(raw);
+											return Number.isNaN(d.getTime())
+												? "미설정"
+												: d.toLocaleDateString("ko-KR", {
+														year: "numeric",
+														month: "long",
+														day: "numeric",
+													});
+										})()}
 									</span>
 								</span>
 								<span className="tutor-assignment-meta-item">

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx
@@ -29,6 +29,18 @@ interface PaginationProps {
 	showItemsPerPage?: boolean;
 }
 
+/** 마감일 문자열을 로컬 기준 "YYYY년 M월 D일"로 포맷 (표시 일관성) */
+function formatDueDate(value: string | undefined): string {
+	if (!value?.trim()) return "미설정";
+	const d = new Date(value);
+	if (Number.isNaN(d.getTime())) return "미설정";
+	return d.toLocaleDateString("ko-KR", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
 interface AssignmentTableViewProps {
 	paginatedAssignments: Assignment[];
 	submissionStats: SubmissionStats;
@@ -103,13 +115,10 @@ const AssignmentTableView: React.FC<AssignmentTableViewProps> = ({
 									</div>
 								</td>
 								<td className="tutor-assignment-due-date-cell">
-									{assignment.dueDate
-										? new Date(assignment.dueDate).toLocaleDateString("ko-KR", {
-												year: "numeric",
-												month: "short",
-												day: "numeric",
-											})
-										: "미설정"}
+									{formatDueDate(
+										assignment.dueDate ??
+											(assignment as { endDate?: string }).endDate,
+									)}
 								</td>
 								<td className="tutor-assignment-problem-count-cell">
 									{assignment.problemCount || 0}개

--- a/src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeTable.tsx
+++ b/src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeTable.tsx
@@ -26,16 +26,19 @@ const NoticeTable: FC<NoticeTableProps> = ({
 		<S.Table>
 			<S.Thead>
 				<tr>
-					<S.Th width="40%" align="left">
+					<S.Th width="35%" align="left">
 						제목
+					</S.Th>
+					<S.Th width="15%" align="left">
+						작성자
 					</S.Th>
 					<S.Th width="20%" align="left">
 						수업
 					</S.Th>
-					<S.Th width="20%" align="right">
+					<S.Th width="15%" align="right">
 						작성일
 					</S.Th>
-					<S.Th width="20%" align="right">
+					<S.Th width="15%" align="right">
 						관리
 					</S.Th>
 				</tr>
@@ -43,7 +46,7 @@ const NoticeTable: FC<NoticeTableProps> = ({
 			<S.Tbody>
 				{notices.length === 0 ? (
 					<tr>
-						<S.EmptyMessage colSpan={4}>
+						<S.EmptyMessage colSpan={5}>
 							{totalCount === 0
 								? "작성된 공지사항이 없습니다."
 								: "검색 조건에 맞는 공지사항이 없습니다."}
@@ -52,7 +55,7 @@ const NoticeTable: FC<NoticeTableProps> = ({
 				) : (
 					notices.map((notice) => (
 						<S.Tr key={String(notice.id)} disabled={notice.active === false}>
-							<S.Td width="40%" align="left">
+							<S.Td width="35%" align="left">
 								<div>
 									<S.NoticeTitle>
 										{notice.title}
@@ -63,17 +66,23 @@ const NoticeTable: FC<NoticeTableProps> = ({
 									)}
 								</div>
 							</S.Td>
+							<S.Td width="15%" align="left">
+								{notice.instructorName ?? "-"}
+							</S.Td>
 							<S.Td width="20%" align="left">
 								{getSectionNameWithoutSection(notice.sectionName)}
 							</S.Td>
-							<S.Td width="20%" align="right">
-								{new Date(notice.createdAt).toLocaleDateString("ko-KR", {
-									year: "numeric",
-									month: "short",
-									day: "numeric",
-								})}
+							<S.Td width="15%" align="right">
+								{(() => {
+									const d = new Date(notice.createdAt);
+									if (Number.isNaN(d.getTime())) return "-";
+									const y = d.getUTCFullYear();
+									const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+									const day = String(d.getUTCDate()).padStart(2, "0");
+									return `${y}.${m}.${day}`;
+								})()}
 							</S.Td>
-							<S.Td width="20%" align="right">
+							<S.Td width="15%" align="right">
 								<S.ActionsInline>
 									<S.PrimaryActions>
 										<S.TableButton

--- a/src/pages/TutorPage/Notices/NoticeManagementPage/types.ts
+++ b/src/pages/TutorPage/Notices/NoticeManagementPage/types.ts
@@ -4,6 +4,7 @@ export interface Notice {
 	content: string;
 	sectionId: number;
 	sectionName: string;
+	instructorName?: string;
 	createdAt: string;
 	active: boolean;
 	isNew?: boolean;


### PR DESCRIPTION
## Frontend (Handongjudge_FE)

### 1. 과제 관리 – 시작일/마감일
- **시작일·마감일 검증**
  - `AssignmentService`(훅) `handleSubmitAdd`, `handleSubmitEdit`: 마감일 < 시작일이면 `alert("마감일은 시작일보다 빠를 수 없습니다.")` 후 API 호출 안 함
  - `AssignmentEditModal`, `AssignmentAddModal`: 제출 전 동일 검증
- **수정 폼 날짜 표시 (UTC → 로컬)**
  - `useAssignmentManagement.ts`: `toLocalDateTimeInputValue()` 추가 후, `handleEdit`에서 `startDate`/`dueDate` 세팅 시 `toISOString().slice(0,16)` 대신 해당 함수 사용
- **목록 정렬**
  - `useAssignmentManagement.ts`: `filteredAssignments`를 마감일(`dueDate`/`endDate`) 기준 **오름차순** 정렬
- **마감일 표시**
  - `AssignmentTableView.tsx`: `formatDueDate()` 도입, `dueDate`/`endDate`를 로컬 기준 `YYYY년 M월 D일` 형태로 표시
  - `AssignmentListView.tsx`: 동일 규칙으로 마감일 표시

### 2. 과제 목록(학생) – 마감일 시간
- **파일:** `CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts`
  - `formatDeadline()` 추가: API UTC → 로컬 `YYYY.MM.DD HH:mm` 형식
- **파일:** `CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx`
  - 마감일 문구를 `[마감일 | {formatDate(endDate)} 23:59 까지 제출]` → `[마감일 | {formatDeadline(endDate)} 까지 제출]` 로 변경 (실제 마감 시각 표시)

### 3. 코딩 테스트 관리 – 날짜/시간
- **파일:** `CodingTestManagement/hooks/useCodingTestManagement.ts`
  - `toLocalDateTimeInputValue()` 추가, 수정 모달에 넣을 때 `startTime`/`endTime`을 로컬 시간으로 변환해 표시
  - `handleEditQuiz`에서 `toISOString().slice(0,16)` 대신 위 함수 사용
  - `fetchQuizzes` 후 목록을 **시작 시간 오름차순**으로 정렬

### 4. 공지사항
- **작성자 표시**
  - `NoticeManagementPage/types.ts`: `Notice`에 `instructorName?: string` 추가
  - `NoticeManagementPage/components/NoticeTable.tsx`: 테이블에 **작성자** 열 추가, `notice.instructorName ?? "-"` 표시 (컬럼 비율 및 colSpan 조정)
- **작성일 표시 (UTC 날짜 기준)**
  - `NoticeTable.tsx`: 작성일을 `getUTCFullYear()`/`getUTCMonth()`/`getUTCDate()`로 포맷 (API 23일 UTC → 23일로 표시)
  - `CourseNoticesPage/hooks/useCourseNoticesPage.ts`: `formatDate`를 UTC 기준 년/월/일로 변경
  - `CourseNoticeDetailPage/hooks/useCourseNoticeDetailPage.ts`: `formatDate` 동일하게 UTC 기준으로 변경

