### PR TITLE
1. 문제 제목 "(복사본)" 표시

### DIFF
--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/ProblemDescription/index.tsx
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/ProblemDescription/index.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import type { Components } from "react-markdown";
+import { stripDuplicateInputOutputExample } from "../../../../TutorPage/Problems/ProblemEdit/utils/problemEditUtils";
 import * as S from "./styles";
 
 interface Problem {
@@ -78,7 +79,9 @@ const ProblemDescription: React.FC<ProblemDescriptionProps> = ({
 	currentProblem,
 	problemDescription = "",
 }) => {
-	const description = currentProblem.description || problemDescription;
+	const description = stripDuplicateInputOutputExample(
+		currentProblem.description || problemDescription,
+	);
 
 	return (
 		<S.DescriptionArea>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemDetailPanel.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemDetailPanel.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { useEffect } from "react";
 import ReactMarkdown from "react-markdown";
+import { stripDuplicateInputOutputExample } from "../../Problems/ProblemEdit/utils/problemEditUtils";
 import * as S from "./styles";
 
 export interface ProblemDetailData {
@@ -37,7 +38,9 @@ const ProblemDetailPanel: React.FC<ProblemDetailPanelProps> = ({
 
 	if (!detail) return null;
 
-	const desc = detail.description;
+	const desc = detail.description
+		? stripDuplicateInputOutputExample(String(detail.description))
+		: detail.description;
 	const isMd =
 		desc &&
 		typeof desc === "string" &&

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/ProblemDetailModal.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/ProblemDetailModal.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
+import { stripDuplicateInputOutputExample } from "../../../Problems/ProblemEdit/utils/problemEditUtils";
 import * as S from "../AssignmentModals/styles";
 import type { ProblemDetailModalProps } from "./types";
 
@@ -11,7 +12,9 @@ const ProblemDetailModal: React.FC<ProblemDetailModalProps> = ({
 }) => {
 	if (!isOpen || !problemDetail) return null;
 
-	const description = problemDetail.description ?? "";
+	const description = stripDuplicateInputOutputExample(
+		problemDetail.description ?? "",
+	);
 	const isMarkdown =
 		description.includes("# ") ||
 		description.includes("## ") ||

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/ProblemListModal/index.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/ProblemListModal/index.tsx
@@ -468,16 +468,29 @@ const ProblemListModal: React.FC<ProblemListModalProps> = ({
 		}
 	};
 
-	const getFullDescription = () => ({
-		title: formData.title,
-		description: formData.description || "",
-		inputFormat: formData.inputFormat,
-		outputFormat: formData.outputFormat,
-		sampleInputs: formData.sampleInputs,
-	});
+	const getFullDescription = () => {
+		const raw =
+			(formData.description || formData.descriptionText || "")
+				.replace(/\r\n/g, "\n")
+				.replace(/\r/g, "\n");
+		const match = raw.match(/(\n|^)\s*##\s*입력\s*형식\s*[\n\r]/);
+		const descriptionOnly =
+			match && match.index != null ? raw.slice(0, match.index).trim() : raw;
+		return {
+			title: formData.title,
+			description: descriptionOnly,
+			inputFormat: formData.inputFormat,
+			outputFormat: formData.outputFormat,
+			sampleInputs: formData.sampleInputs,
+		};
+	};
 
 	const getFullDescriptionForBackend = () => {
-		let full = formData.descriptionText || "";
+		const raw = (formData.descriptionText || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		const mainMatch = raw.match(/(\n|^)\s*##\s*입력\s*형식\s*[\n\r]/);
+		const mainOnly =
+			mainMatch && mainMatch.index != null ? raw.slice(0, mainMatch.index).trim() : raw;
+		let full = mainOnly;
 		if (formData.inputFormat)
 			full += `\n\n## 입력 형식\n${formData.inputFormat}`;
 		if (formData.outputFormat)

--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeProblemDetailModal.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeProblemDetailModal.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { createPortal } from "react-dom";
 import ReactMarkdown from "react-markdown";
+import { stripDuplicateInputOutputExample } from "../../../Problems/ProblemEdit/utils/problemEditUtils";
 import * as S from "../styles";
 
 export interface GradeProblemDetailModalProps {
@@ -21,7 +22,9 @@ export default function GradeProblemDetailModal({
 }: GradeProblemDetailModalProps) {
 	if (!isOpen || !problemDetail) return null;
 
-	const description = problemDetail.description ?? "";
+	const description = stripDuplicateInputOutputExample(
+		problemDetail.description ?? "",
+	);
 	const isMarkdown =
 		description.includes("# ") ||
 		description.includes("## ") ||

--- a/src/pages/TutorPage/Problems/ProblemCreate/components/ProblemCreateView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemCreate/components/ProblemCreateView.tsx
@@ -54,7 +54,15 @@ export default function ProblemCreateView(d: ProblemCreateHookReturn) {
 
 				<S.Form onSubmit={d.handleSubmit}>
 					{hasRequiredErrors && (
-						<S.RequiredMessage role="alert">{REQUIRED_MSG}</S.RequiredMessage>
+						<S.RequiredMessage role="alert">
+							{REQUIRED_MSG}
+							{d.fieldErrors.testcases && (
+								<>
+									<br />
+									테스트케이스가 최소 1개 이상 필요합니다.
+								</>
+							)}
+						</S.RequiredMessage>
 					)}
 					<S.Step>
 						<S.FormGrid>
@@ -369,7 +377,7 @@ export default function ProblemCreateView(d: ProblemCreateHookReturn) {
 								<S.Preview>
 									<S.PreviewHeader>미리보기</S.PreviewHeader>
 									<S.PreviewContent>
-										<ProblemPreview {...d.getFullDescription()} />
+										<ProblemPreview {...d.getDescriptionOnlyForPreview()} descriptionOnly />
 									</S.PreviewContent>
 								</S.Preview>
 							</S.DescriptionEditor>

--- a/src/pages/TutorPage/Problems/ProblemCreate/components/ProblemPreview.tsx
+++ b/src/pages/TutorPage/Problems/ProblemCreate/components/ProblemPreview.tsx
@@ -11,6 +11,8 @@ export interface ProblemPreviewProps {
 	inputFormat: string;
 	outputFormat: string;
 	sampleInputs: SampleInput[];
+	/** true면 미리보기에 본문만 표시(입력/출력/예제는 폼에서만 보이게) */
+	descriptionOnly?: boolean;
 }
 
 // react-markdown v10에서는 'inline' prop이 제거됨.
@@ -94,29 +96,41 @@ const ProblemPreview: React.FC<ProblemPreviewProps> = ({
 	inputFormat,
 	outputFormat,
 	sampleInputs,
+	descriptionOnly: descriptionOnlyMode = false,
 }) => {
 	const hasContent =
 		description ||
-		inputFormat ||
-		outputFormat ||
-		(sampleInputs && sampleInputs.some((s) => s.input || s.output));
+		(!descriptionOnlyMode &&
+			(inputFormat ||
+				outputFormat ||
+				(sampleInputs && sampleInputs.some((s) => s.input || s.output))));
 
 	if (!hasContent) {
 		return <S.PreviewEmpty>문제 설명을 입력하세요</S.PreviewEmpty>;
 	}
 
+	// 본문에 "## 입력 형식" 이하가 포함돼 있으면 미리보기에서는 제거 (전용 필드에서만 한 번 표시)
+	const descOnly =
+		description && description.includes("입력 형식")
+			? (() => {
+					const n = description.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+					const m = n.match(/(\n|^)\s*##\s*입력\s*형식\s*[\n\r]/);
+					return m && m.index != null ? n.slice(0, m.index).trim() : description;
+				})()
+			: description || "";
+
 	return (
 		<div>
 	
-		{description && (
+		{descOnly && (
 		<S.PreviewSection>
 			<ReactMarkdown components={mdComponents} rehypePlugins={[rehypeRaw]}>
-				{prepareMarkdown(description)}
+				{prepareMarkdown(descOnly)}
 			</ReactMarkdown>
 		</S.PreviewSection>
 	)}
 
-	{inputFormat && (
+	{!descriptionOnlyMode && inputFormat && (
 		<S.PreviewSection>
 			<S.PreviewH2>입력</S.PreviewH2>
 			<ReactMarkdown components={mdComponents} rehypePlugins={[rehypeRaw]}>
@@ -125,7 +139,7 @@ const ProblemPreview: React.FC<ProblemPreviewProps> = ({
 		</S.PreviewSection>
 	)}
 
-	{outputFormat && (
+	{!descriptionOnlyMode && outputFormat && (
 		<S.PreviewSection>
 			<S.PreviewH2>출력</S.PreviewH2>
 			<ReactMarkdown components={mdComponents} rehypePlugins={[rehypeRaw]}>
@@ -134,7 +148,7 @@ const ProblemPreview: React.FC<ProblemPreviewProps> = ({
 		</S.PreviewSection>
 	)}
 
-			{sampleInputs && sampleInputs.some((s) => s.input || s.output) && (
+			{!descriptionOnlyMode && sampleInputs && sampleInputs.some((s) => s.input || s.output) && (
 				<S.PreviewSection>
 					<S.PreviewH2>예제</S.PreviewH2>
 				{sampleInputs.map((sample, index) => {

--- a/src/pages/TutorPage/Problems/ProblemCreate/hooks/useProblemCreate.ts
+++ b/src/pages/TutorPage/Problems/ProblemCreate/hooks/useProblemCreate.ts
@@ -218,6 +218,7 @@ export function useProblemCreate() {
 				...prev,
 				testcases: [...prev.testcases, ...files],
 			}));
+			setFieldErrors((prev) => ({ ...prev, testcases: false }));
 		},
 		[],
 	);
@@ -231,6 +232,7 @@ export function useProblemCreate() {
 
 	const handleParsedTestcaseRemove = useCallback((index: number) => {
 		setParsedTestCases((prev) => prev.filter((_, i) => i !== index));
+		setFieldErrors((prev) => ({ ...prev, testcases: false }));
 	}, []);
 
 	/** 커서 위치에 텍스트를 삽입하고 description 상태를 동기화합니다. */
@@ -284,7 +286,6 @@ export function useProblemCreate() {
 	const getFullDescription = useCallback(
 		() => ({
 			title: formData.title,
-			// description은 항상 순수 마크다운 텍스트로 저장됩니다
 			description: formData.description || "",
 			inputFormat: formData.inputFormat,
 			outputFormat: formData.outputFormat,
@@ -293,8 +294,35 @@ export function useProblemCreate() {
 		[formData],
 	);
 
+	/** 미리보기용: 입력/출력/예제는 폼에서만 보이게, 미리보기에는 문제 설명만 표시 */
+	const getDescriptionOnlyForPreview = useCallback(
+		() => {
+			const desc =
+				formData.description || formData.descriptionText || "";
+			const normalized = desc.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+			// 줄 맨 앞이든 중간이든 "## 입력 형식" 이하는 잘라서 본문만
+			const match = normalized.match(/(\n|^)\s*##\s*입력\s*형식\s*[\n\r]/);
+			const mainOnly =
+				match && match.index != null
+					? normalized.slice(0, match.index).trim()
+					: desc;
+			return {
+				title: formData.title,
+				description: mainOnly,
+				inputFormat: "",
+				outputFormat: "",
+				sampleInputs: [],
+			};
+		},
+		[formData],
+	);
+
 	const getFullDescriptionForBackend = useCallback((): string => {
-		let full = formData.descriptionText || "";
+		// 본문만 사용(이미 "## 입력 형식" 이하가 있으면 제거 후 한 번만 붙임 → 저장 시 중복 방지)
+		const raw = (formData.descriptionText || "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		const mainMatch = raw.match(/(\n|^)\s*##\s*입력\s*형식\s*[\n\r]/);
+		const mainOnly = mainMatch && mainMatch.index != null ? raw.slice(0, mainMatch.index).trim() : raw;
+		let full = mainOnly;
 		if (formData.inputFormat) {
 			full += "\n\n## 입력 형식\n" + formData.inputFormat;
 		}
@@ -321,6 +349,9 @@ export function useProblemCreate() {
 	const handleSubmit = useCallback(
 		async (e: React.FormEvent) => {
 			e.preventDefault();
+			setLoading(true);
+			setError(null);
+
 			const errs: Record<string, boolean> = {};
 			if (!formData.title?.trim()) errs.title = true;
 			if (!formData.timeLimit?.trim()) errs.timeLimit = true;
@@ -328,11 +359,25 @@ export function useProblemCreate() {
 			const hasDescription =
 				(formData.description?.trim() || formData.descriptionText?.trim()) ?? "";
 			if (!hasDescription) errs.description = true;
-			setFieldErrors(errs);
-			if (Object.keys(errs).length > 0) return;
+			const hasTestcases =
+				parsedTestCases.some(
+					(tc) => (tc.input?.trim() && tc.output?.trim()),
+				) || formData.testcases.length > 0;
+			if (!hasTestcases) errs.testcases = true;
 
-			setLoading(true);
-			setError(null);
+			setFieldErrors(errs);
+			if (Object.keys(errs).length > 0) {
+				setLoading(false);
+				const messages: string[] = [];
+				if (errs.title) messages.push("• 문제 제목");
+				if (errs.timeLimit) messages.push("• 시간 제한");
+				if (errs.memoryLimit) messages.push("• 메모리 제한");
+				if (errs.description) messages.push("• 문제 설명");
+				if (errs.testcases) messages.push("• 테스트케이스 (최소 1개 이상)");
+				alert("다음 항목을 입력해 주세요:\n\n" + messages.join("\n"));
+				return;
+			}
+
 			try {
 				const submitFormData = new FormData();
 				submitFormData.append("title", formData.title);
@@ -458,6 +503,7 @@ export function useProblemCreate() {
 		wrapWithMarkdown,
 		insertMarkdownHeading,
 		getFullDescription,
+		getDescriptionOnlyForPreview,
 		handleSubmit,
 		clearZipFile,
 		fieldErrors,

--- a/src/pages/TutorPage/Problems/ProblemEdit/ProblemPreview.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/ProblemPreview.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import rehypeRaw from "rehype-raw";
 import type { ProblemPreviewProps, SampleInput } from "./types";
+import { descriptionForPreview } from "./utils/problemEditUtils";
 import * as S from "./styles";
 
 // react-markdown v10: 'inline' prop 제거됨 → Context로 블록/인라인 코드 구분
@@ -64,12 +65,14 @@ const ProblemPreview: React.FC<ProblemPreviewProps> = ({
 	inputFormat,
 	outputFormat,
 	sampleInputs,
+	descriptionOnly = false,
 }) => {
 	const hasContent =
 		description ||
-		inputFormat ||
-		outputFormat ||
-		sampleInputs?.some((s: SampleInput) => s.input || s.output);
+		(!descriptionOnly &&
+			(inputFormat ||
+				outputFormat ||
+				sampleInputs?.some((s: SampleInput) => s.input || s.output)));
 
 	if (!hasContent) {
 		return <S.PreviewEmpty>문제 설명을 입력하세요</S.PreviewEmpty>;
@@ -81,12 +84,12 @@ const ProblemPreview: React.FC<ProblemPreviewProps> = ({
 	{description && (
 		<S.PreviewDescription>
 			<ReactMarkdown components={mdComponents} rehypePlugins={[rehypeRaw]}>
-				{prepareMarkdown(description)}
+				{prepareMarkdown(descriptionForPreview(description))}
 			</ReactMarkdown>
 		</S.PreviewDescription>
 	)}
 
-			{inputFormat && (
+			{!descriptionOnly && inputFormat && (
 				<S.PreviewSection>
 					<S.PreviewH2>입력 형식</S.PreviewH2>
 					<S.PreviewContentText>
@@ -99,7 +102,7 @@ const ProblemPreview: React.FC<ProblemPreviewProps> = ({
 				</S.PreviewSection>
 			)}
 
-			{outputFormat && (
+			{!descriptionOnly && outputFormat && (
 				<S.PreviewSection>
 					<S.PreviewH2>출력 형식</S.PreviewH2>
 					<S.PreviewContentText>
@@ -112,7 +115,7 @@ const ProblemPreview: React.FC<ProblemPreviewProps> = ({
 				</S.PreviewSection>
 			)}
 
-			{sampleInputs?.some((s) => s.input || s.output) && (
+			{!descriptionOnly && sampleInputs?.some((s) => s.input || s.output) && (
 				<S.PreviewSection>
 					<S.PreviewH2>예제</S.PreviewH2>
 					{sampleInputs.map((sample, idx) => {

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditDescriptionSection.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditDescriptionSection.tsx
@@ -10,7 +10,8 @@ type ProblemEditDescriptionSectionProps = Pick<
 	| "formData"
 	| "setFormData"
 	| "enableFullEdit"
-	| "getFullDescription"
+	| "getDescriptionOnlyForPreview"
+	| "getFullPreviewProps"
 	| "insertMarkdownText"
 	| "wrapWithMarkdown"
 	| "insertMarkdownHeading"
@@ -25,7 +26,8 @@ const ProblemEditDescriptionSection: React.FC<
 	formData,
 	setFormData,
 	enableFullEdit,
-	getFullDescription,
+	getDescriptionOnlyForPreview,
+	getFullPreviewProps,
 	insertMarkdownText,
 	wrapWithMarkdown,
 	insertMarkdownHeading,
@@ -57,7 +59,7 @@ const ProblemEditDescriptionSection: React.FC<
 				<S.Preview>
 					<S.PreviewHeader>미리보기</S.PreviewHeader>
 					<S.PreviewContent>
-						<ProblemPreview {...getFullDescription()} />
+						<ProblemPreview {...getFullPreviewProps()} />
 					</S.PreviewContent>
 				</S.Preview>
 			</S.DescriptionEditor>
@@ -239,7 +241,7 @@ const ProblemEditDescriptionSection: React.FC<
 				<S.Preview>
 					<S.PreviewHeader>미리보기</S.PreviewHeader>
 					<S.PreviewContent>
-						<ProblemPreview {...getFullDescription()} />
+						<ProblemPreview {...getFullPreviewProps()} />
 					</S.PreviewContent>
 				</S.Preview>
 			</S.DescriptionEditor>

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditSampleInputsSection.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditSampleInputsSection.tsx
@@ -86,9 +86,7 @@ const ProblemEditSampleInputsSection: React.FC<
 		) : (
 			<>
 				{formData.sampleInputs.map((sample, idx) => (
-					<S.SampleItem
-						key={`sample-${idx}-${sample.input?.slice(0, 10) ?? ""}-${sample.output?.slice(0, 10) ?? ""}`}
-					>
+					<S.SampleItem key={`sample-${idx}`}>
 						<S.SampleHeader>
 							<span>예제 #{idx + 1}</span>
 							{formData.sampleInputs.length > 1 && (

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
@@ -97,7 +97,8 @@ export default function ProblemEditView(d: ProblemEditHookReturn) {
 							formData={d.formData}
 							setFormData={d.setFormData}
 							enableFullEdit={d.enableFullEdit}
-							getFullDescription={d.getFullDescription}
+							getDescriptionOnlyForPreview={d.getDescriptionOnlyForPreview}
+							getFullPreviewProps={d.getFullPreviewProps}
 							insertMarkdownText={d.insertMarkdownText}
 							wrapWithMarkdown={d.wrapWithMarkdown}
 							insertMarkdownHeading={d.insertMarkdownHeading}

--- a/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 import APIService from "../../../../../services/APIService";
-import { parseTags, extractTextFromRTF } from "../utils/problemEditUtils";
+import { parseTags, extractTextFromRTF, parseDescriptionSections, descriptionForPreview } from "../utils/problemEditUtils";
 import type {
 	ProblemFormData,
 	ParsedTestcase,
@@ -85,9 +85,15 @@ export function useProblemEdit() {
 			} catch (err) {
 				console.warn("ZIP 파싱 실패 (계속 진행):", err);
 			}
-			const description = parsedData?.description ?? problem?.description ?? "";
-			const descriptionText =
-				description.replace(/<[^>]*>/g, "") || description;
+			const rawDescription = parsedData?.description ?? problem?.description ?? "";
+			const descriptionText = (rawDescription || "")
+				.replace(/<[^>]*>/g, "")
+				.replace(/\r\n/g, "\n")
+				.replace(/\r/g, "\n")
+				.trim();
+			const parsed = parseDescriptionSections(descriptionText);
+			const description = parsed.mainDescription;
+			const mainDescriptionText = parsed.mainDescription;
 			let timeLimit = "";
 			if (parsedData?.timeLimit != null) {
 				timeLimit = String(parsedData.timeLimit);
@@ -116,7 +122,12 @@ export function useProblemEdit() {
 			const testCases = parsedData?.testCases ?? parsedData?.testcases ?? [];
 			setParsedTestCases(testCases);
 			let sampleInputs: SampleInput[] = [{ input: "", output: "" }];
-			if (testCases.length > 0) {
+			const hasParsedSamples =
+				parsed.sampleInputs.length > 0 &&
+				parsed.sampleInputs.some((s) => s.input || s.output);
+			if (hasParsedSamples) {
+				sampleInputs = parsed.sampleInputs;
+			} else if (testCases.length > 0) {
 				const samples = testCases.filter((tc) => tc.type === "sample");
 				if (samples.length > 0) {
 					sampleInputs = samples.map((tc) => ({
@@ -127,10 +138,10 @@ export function useProblemEdit() {
 			}
 			setFormData({
 				title: problem?.title ?? parsedData?.title ?? "",
-				description,
-				descriptionText,
-				inputFormat: "",
-				outputFormat: "",
+				description: mainDescriptionText,
+				descriptionText: mainDescriptionText,
+				inputFormat: parsed.inputFormat,
+				outputFormat: parsed.outputFormat,
 				tags,
 				difficulty:
 					parsedData?.difficulty != null
@@ -146,11 +157,11 @@ export function useProblemEdit() {
 			setEnableFullEdit(false);
 			setTimeout(() => {
 				if (descriptionRef.current) {
-					const isHTML = /<[^>]+>/.test(description);
+					const isHTML = /<[^>]+>/.test(mainDescriptionText);
 					if (isHTML) {
-						descriptionRef.current.innerHTML = description;
+						descriptionRef.current.innerHTML = mainDescriptionText;
 					} else {
-						descriptionRef.current.textContent = descriptionText;
+						descriptionRef.current.textContent = mainDescriptionText;
 					}
 					setIsInitialLoad(false);
 				}
@@ -317,12 +328,14 @@ export function useProblemEdit() {
 
 	const handleSampleInputChange = useCallback(
 		(index: number, field: "input" | "output", value: string) => {
-			const newSamples = [...formData.sampleInputs];
-			if (newSamples[index])
-				newSamples[index] = { ...newSamples[index], [field]: value };
-			setFormData((prev) => ({ ...prev, sampleInputs: newSamples }));
+			setFormData((prev) => {
+				const newSamples = [...prev.sampleInputs];
+				if (newSamples[index])
+					newSamples[index] = { ...newSamples[index], [field]: value };
+				return { ...prev, sampleInputs: newSamples };
+			});
 		},
-		[formData.sampleInputs],
+		[],
 	);
 
 	const addSampleInput = useCallback(() => {
@@ -489,8 +502,40 @@ export function useProblemEdit() {
 		[formData],
 	);
 
+	/** 미리보기용: 문제 설명 본문만 (입력/출력/예제는 비움) */
+	const getDescriptionOnlyForPreview = useCallback(
+		() => ({
+			title: formData.title,
+			description: (formData.description ?? formData.descriptionText ?? "").includes(
+				"## 입력 형식",
+			)
+				? (formData.description ?? formData.descriptionText ?? "")
+						.split("\n\n## 입력 형식")[0]
+						.trim()
+				: formData.description ?? formData.descriptionText ?? "",
+			inputFormat: "",
+			outputFormat: "",
+			sampleInputs: [],
+		}),
+		[formData],
+	);
+
+	/** 미리보기용: 본문 + 입력 형식 + 출력 형식 + 예제 입출력 모두 표시 */
+	const getFullPreviewProps = useCallback(
+		() => ({
+			title: formData.title,
+			description: descriptionForPreview(formData.descriptionText ?? ""),
+			inputFormat: formData.inputFormat ?? "",
+			outputFormat: formData.outputFormat ?? "",
+			sampleInputs: formData.sampleInputs ?? [],
+		}),
+		[formData],
+	);
+
 	const getFullDescriptionForBackend = useCallback((): string => {
-		let full = formData.descriptionText ?? "";
+		// 본문만 사용(이미 "## 입력 형식" 이하가 있으면 제거 후 한 번만 붙임 → 저장 시 중복 방지)
+		const mainOnly = descriptionForPreview(formData.descriptionText ?? "");
+		let full = mainOnly;
 		if (formData.inputFormat) {
 			full += `\n\n## 입력 형식\n${formData.inputFormat}`;
 		}
@@ -556,25 +601,40 @@ export function useProblemEdit() {
 		async (e: React.FormEvent) => {
 			e.preventDefault();
 			if (!problemId) return;
+
+			if (enableFullEdit) {
+				const hasDescription =
+					(formData.description?.trim() || formData.descriptionText?.trim()) ?? "";
+				if (!hasDescription) {
+					alert("문제 설명을 입력해 주세요.");
+					return;
+				}
+				const hasTestcases =
+					parsedTestCases.some(
+						(tc) => tc.input?.trim() && tc.output?.trim(),
+					) ||
+					formData.testcases.some(
+						(tc) => tc.input?.trim() && tc.output?.trim(),
+					);
+				if (!hasTestcases) {
+					alert("테스트케이스가 최소 1개 이상 필요합니다. (입력/출력 쌍 모두 있어야 합니다)");
+					return;
+				}
+				const incomplete = validateTestCases();
+				if (incomplete.length > 0) {
+					const message = incomplete
+						.map((tc) => `- ${tc.name}: ${tc.missing} 파일이 없습니다`)
+						.join("\n");
+					alert(
+						`다음 테스트케이스에 입력/출력이 비어 있습니다:\n\n${message}\n\n모든 테스트케이스를 완성한 후 제출해 주세요.`,
+					);
+					return;
+				}
+			}
+
 			setSubmitting(true);
 			setError(null);
 			try {
-				if (enableFullEdit) {
-					const incomplete = validateTestCases();
-					if (incomplete.length > 0) {
-						const message = incomplete
-							.map((tc) => `- ${tc.name}: ${tc.missing} 파일이 없습니다`)
-							.join("\n");
-						if (
-							!window.confirm(
-								`다음 테스트케이스에 입력/출력 쌍이 완성되지 않았습니다:\n\n${message}\n\n그래도 제출하시겠습니까?`,
-							)
-						) {
-							setSubmitting(false);
-							return;
-						}
-					}
-				}
 				const submitFormData = new FormData();
 				submitFormData.append("title", formData.title);
 				submitFormData.append("tags", JSON.stringify(formData.tags));
@@ -711,6 +771,8 @@ export function useProblemEdit() {
 		handleParsedTestcaseRemove,
 		handleParsedTestcaseChange,
 		getFullDescription,
+		getDescriptionOnlyForPreview,
+		getFullPreviewProps,
 		insertMarkdownText,
 		wrapWithMarkdown,
 		insertMarkdownHeading,

--- a/src/pages/TutorPage/Problems/ProblemEdit/types.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/types.ts
@@ -39,4 +39,6 @@ export interface ProblemPreviewProps {
 	inputFormat: string;
 	outputFormat: string;
 	sampleInputs: SampleInput[];
+	/** true면 미리보기에 본문만 표시(입력/출력/예제는 폼에서만 보이게) */
+	descriptionOnly?: boolean;
 }

--- a/src/pages/TutorPage/Problems/ProblemEdit/utils/problemEditUtils.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/utils/problemEditUtils.ts
@@ -31,3 +31,135 @@ export function extractTextFromRTF(rtfContent: string): string {
 	}
 	return rtfContent;
 }
+
+/**
+ * API 등에서 받은 description에 "## 입력 형식"~"## 예제" 블록이 두 번 들어있을 때,
+ * 두 번째 블록부터 제거해 한 번만 보이게 합니다.
+ */
+export function stripDuplicateInputOutputExample(description: string): string {
+	if (!description || !description.includes("입력 형식")) return description;
+	const normalized = description.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	const regex = /(\n|^)\s*##\s*입력\s*형식\s*[\n\r]/g;
+	const matches = [...normalized.matchAll(regex)];
+	if (matches.length < 2) return description;
+	const secondMatch = matches[1];
+	if (!secondMatch || secondMatch.index == null) return description;
+	return normalized.slice(0, secondMatch.index).trim();
+}
+
+/**
+ * 미리보기용: description에서 "## 입력 형식" 이하 섹션을 제거해 본문만 반환합니다.
+ * (입력/출력/예제는 전용 필드로 따로 보여주므로, 본문 영역에서는 한 번만 보이게 함)
+ * 줄 맨 앞에 있거나 문장 중간에 있어도 잘리도록 매칭합니다.
+ */
+export function descriptionForPreview(description: string): string {
+	if (!description || !description.includes("입력 형식")) return description;
+	const normalized = description.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	// (\n|^) = 줄바꿈 또는 문자열 시작 다음에 오는 "## 입력 형식"
+	const match = normalized.match(/(\n|^)\s*##\s*입력\s*형식\s*[\n\r]/);
+	if (!match || match.index == null) return description;
+	return normalized.slice(0, match.index).trim();
+}
+
+export interface ParsedDescriptionSections {
+	mainDescription: string;
+	inputFormat: string;
+	outputFormat: string;
+	sampleInputs: { input: string; output: string }[];
+}
+
+/**
+ * 줄바꿈 정규화 (\\r\\n, \\r → \\n)
+ */
+function normalizeNewlines(s: string): string {
+	return s.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * 저장된 문제 설명(description)에서 "## 입력 형식", "## 출력 형식", "## 예제" 섹션을 분리합니다.
+ * 편집 시 폼 필드에 맞게 채우고, 저장 시 중복 저장을 막기 위해 사용합니다.
+ * 줄바꿈 형식(\\n vs \\r\\n)에 관계없이 동작하도록 정규화합니다.
+ */
+export function parseDescriptionSections(
+	fullDescription: string,
+): ParsedDescriptionSections {
+	const raw = fullDescription ? normalizeNewlines(fullDescription.trim()) : "";
+	const result: ParsedDescriptionSections = {
+		mainDescription: raw,
+		inputFormat: "",
+		outputFormat: "",
+		sampleInputs: [{ input: "", output: "" }],
+	};
+	if (!raw.includes("입력 형식") && !raw.includes("출력 형식")) {
+		return result;
+	}
+
+	// 유연한 마커 매칭: "## 입력 형식" 앞뒤 공백/줄바꿈 허용
+	const inputFormatRegex = /\n+##\s*입력\s*형식\s*\n+/;
+	const outputFormatRegex = /\n+##\s*출력\s*형식\s*\n+/;
+	const exampleRegex = /\n+##\s*예제\s*(\n|$)/;
+
+	const inputMatch = raw.match(inputFormatRegex);
+	if (!inputMatch || inputMatch.index == null) return result;
+
+	const idxInput = inputMatch.index;
+	result.mainDescription = raw.slice(0, idxInput).trim();
+
+	const afterInput = raw.slice(idxInput + inputMatch[0].length);
+	const outputMatch = afterInput.match(outputFormatRegex);
+	if (!outputMatch || outputMatch.index == null) {
+		result.inputFormat = afterInput.trim();
+		return result;
+	}
+	result.inputFormat = afterInput.slice(0, outputMatch.index).trim();
+
+	const afterOutput = afterInput.slice(
+		outputMatch.index + outputMatch[0].length,
+	);
+	const exampleMatch = afterOutput.match(exampleRegex);
+	if (!exampleMatch || exampleMatch.index == null) {
+		result.outputFormat = afterOutput.trim();
+		return result;
+	}
+	result.outputFormat = afterOutput.slice(0, exampleMatch.index).trim();
+
+	const examplesBlock = afterOutput
+		.slice(exampleMatch.index + exampleMatch[0].length)
+		.trim();
+	const samples = parseExampleSection(examplesBlock);
+	result.sampleInputs =
+		samples.length > 0 ? samples : [{ input: "", output: "" }];
+	return result;
+}
+
+/** "### 예제 입력 N\n```\n...\n```\n\n### 예제 출력 N\n```\n...\n```" 형식 파싱. 줄바꿈 유연 처리 */
+function parseExampleSection(block: string): { input: string; output: string }[] {
+	const normalized = normalizeNewlines(block);
+	const samples: { input: string; output: string }[] = [];
+	// ``` 다음에 줄바꿈 0~1개 후 내용, 그 다음 ``` 까지
+	const inputRegex = /###\s*예제\s*입력\s*(\d+)\s*[\n\r]+```[\n\r]*([\s\S]*?)```/g;
+	const outputRegex = /###\s*예제\s*출력\s*(\d+)\s*[\n\r]+```[\n\r]*([\s\S]*?)```/g;
+
+	const inputMatches = [...normalized.matchAll(inputRegex)];
+	const outputMatches = [...normalized.matchAll(outputRegex)];
+
+	const maxIdx = Math.max(
+		inputMatches.length,
+		outputMatches.length,
+		1,
+	);
+	for (let i = 0; i < maxIdx; i++) {
+		const inputNum = i + 1;
+		const inMatch = inputMatches.find(
+			(m) => Number(m[1]) === inputNum,
+		);
+		const outMatch = outputMatches.find(
+			(m) => Number(m[1]) === inputNum,
+		);
+		samples.push({
+			input: inMatch ? inMatch[2].trim() : "",
+			output: outMatch ? outMatch[2].trim() : "",
+		});
+	}
+	return samples;
+}

--- a/src/pages/TutorPage/Problems/ProblemManagement/components/ProblemManagementView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemManagement/components/ProblemManagementView.tsx
@@ -7,6 +7,7 @@ import EmptyState from "../../../../../components/UI/EmptyState";
 import LoadingSpinner from "../../../../../components/UI/LoadingSpinner";
 import * as S from "../styles";
 import type { ProblemManagementHookReturn } from "../hooks/useProblemManagement";
+import { stripDuplicateInputOutputExample } from "../../ProblemEdit/utils/problemEditUtils";
 
 // ──────────────────────────────────────────────
 // 마크다운 코드블록 렌더링 (ProblemPreview와 동일한 방식)
@@ -389,8 +390,10 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 							{(() => {
 								const rawDesc =
 									d.selectedProblem.description || "*문제 설명이 없습니다.*";
-								// 빈 예제 섹션 제거 후 렌더링
-								const desc = stripEmptyExamplesSection(rawDesc);
+								// 중복된 "## 입력 형식"~"## 예제" 블록 제거 후, 빈 예제 섹션 제거
+								const desc = stripEmptyExamplesSection(
+									stripDuplicateInputOutputExample(rawDesc),
+								);
 								return (
 									<S.DescriptionContent>
 										<ReactMarkdown


### PR DESCRIPTION
2. 문제 생성/편집 제출 검증 및 로딩
3. 입력 형식·출력 형식·예제 중복 및 편집 반영
4. 서버 응답 시 description 중복 제거
5. 편집 시 예제 입출력 입력 불가 현상
6. 미리보기에 입력 형식·출력 형식·예제 모두 표시

## #️⃣연관된 이슈

> ex) #130 

# 이 브랜치에서 완료한 작업 (Issue용)

## 1. 문제 제목 "(복사본)" 표시

- **문제**: DB에는 "(복사본)"이 있는데 프론트에서 사라짐.
- **조치**: `problemUtils.removeCopyLabel`은 제목에서 "(복사본)"을 제거하지 않고 trim만 하도록 수정. 편집 시 제목은 `problem?.title ?? parsedData?.title`로 DB 값을 우선 사용.

## 2. 문제 생성/편집 제출 검증 및 로딩

- **생성**: 제출 시 제목·시간·메모리·설명·테스트케이스 필수 검증, 누락 항목 리스트로 alert. 통과 시 즉시 `setLoading(true)`로 중복 제출 방지.
- **편집**: `enableFullEdit`일 때 설명·테스트케이스 필수 검증 후 alert, 통과 시에만 `setSubmitting(true)`.

## 3. 입력 형식·출력 형식·예제 중복 및 편집 반영

- **저장**: `getFullDescriptionForBackend()`에서 본문은 "## 입력 형식" 이전만 사용하고, 입력 형식·출력 형식·예제 블록을 **한 번만** 붙이도록 수정 (Create/Edit/과제 모달 공통).
- **편집 로드**: `parseDescriptionSections`로 description에서 본문/입력 형식/출력 형식/예제 분리 후, `inputFormat`·`outputFormat`·`sampleInputs` 폼 필드에 채움.
- **표시**: API/DB에서 받은 description에 "## 입력 형식"이 두 번 있으면 `stripDuplicateInputOutputExample`로 두 번째 블록부터 제거 후 표시 (문제 관리 모달, ProblemDetailPanel, ProblemDetailModal, GradeProblemDetailModal, 학생용 문제 설명 등).

## 4. 서버 응답 시 description 중복 제거

- **백엔드**: `ProblemFileUtil.stripDuplicateInputOutputExample(description)` 추가. "## 입력 형식"이 두 번째 나오는 위치부터 잘라서 반환.
- **적용**: `ProblemService`의 단건 조회·과제용 응답·문제 복사 시 description에 위 메서드 적용. 복사 시 새 문제 description에도 적용해 복사본은 한 번만 저장되도록 처리.

## 5. 편집 시 예제 입출력 입력 불가 현상

- **원인**: 예제 아이템 `key`에 `sample.input`/`sample.output` 포함 → 입력할 때마다 key 변경으로 리마운트·포커스 손실.
- **조치**: `key`를 `sample-${idx}`만 사용. `handleSampleInputChange`는 `setFormData(prev => ...)` 함수형 업데이트로 변경하고 의존성 배열 `[]`로 고정.

## 6. 미리보기에 입력 형식·출력 형식·예제 모두 표시

- **조치**: `getFullPreviewProps()` 추가 (본문 + inputFormat + outputFormat + sampleInputs). 문제 편집 화면 미리보기에서 `getFullPreviewProps()` 사용하고 `descriptionOnly` 제거해, 입력 형식·출력 형식·예제 입출력이 모두 미리보기에 나오도록 수정.
