### PR TITLE
fix/src/fix과제-완료율-표시-및-마감-시간-이후에도-제출가능하게

### DIFF
--- a/src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts
+++ b/src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts
@@ -349,11 +349,7 @@ export function useProblemSolve() {
 		}
 		if (!sectionId || !problemId) return;
 
-		// 마감일 및 비활성화 체크
-		if (isDeadlinePassed) {
-			alert("과제 마감일이 지났습니다.");
-			return;
-		}
+		// 비활성화 체크 (마감일 지나면 지각 제출로 허용)
 		// 관리자/튜터는 비활성화된 과제도 제출 가능
 		const isManager = userRole === "ADMIN" || userRole === "TUTOR";
 		if (!isAssignmentActive && !isManager) {
@@ -392,27 +388,19 @@ export function useProblemSolve() {
 		} catch (error: unknown) {
 			const message =
 				error instanceof Error ? error.message : "코드 제출에 실패했습니다.";
-			
-			// 백엔드에서 마감일/비활성화 에러 응답 처리
+			// 백엔드에서 비활성화 에러만 처리 (마감일 지나면 지각 제출 허용)
 			if (
-				message.includes("마감일") ||
 				message.includes("비활성화") ||
 				message.includes("제출할 수 없습니다")
 			) {
-				setIsDeadlinePassed(message.includes("마감일"));
-				if (message.includes("비활성화")) {
-					setIsAssignmentActive(false);
-					// 비활성화된 과제인 경우 알림 후 리다이렉트
-					alert(message);
-					setTimeout(() => {
-						navigate(`/sections/${sectionId}/course-assignments`);
-					}, 1000);
-					setIsSubmitting(false);
-					return;
-				}
+				setIsAssignmentActive(false);
 				alert(message);
+				setTimeout(() => {
+					navigate(`/sections/${sectionId}/course-assignments`);
+				}, 1000);
+				setIsSubmitting(false);
+				return;
 			}
-
 			setSubmissionResult({
 				status: "error",
 				message,
@@ -422,7 +410,7 @@ export function useProblemSolve() {
 		} finally {
 			setIsSubmitting(false);
 		}
-	}, [code, language, sectionId, problemId, clearSessionAfterSubmission, isDeadlinePassed, isAssignmentActive, navigate, userRole]);
+	}, [code, language, sectionId, problemId, clearSessionAfterSubmission, isAssignmentActive, navigate, userRole]);
 
 	const handleSubmitWithOutput = useCallback(async () => {
 		if (!code.trim()) {
@@ -431,11 +419,7 @@ export function useProblemSolve() {
 		}
 		if (!sectionId || !problemId) return;
 
-		// 마감일 및 비활성화 체크
-		if (isDeadlinePassed) {
-			alert("과제 마감일이 지났습니다.");
-			return;
-		}
+		// 비활성화 체크 (마감일 지나면 지각 제출로 허용)
 		// 관리자/튜터는 비활성화된 과제도 테스트 가능
 		const isManager = userRole === "ADMIN" || userRole === "TUTOR";
 		if (!isAssignmentActive && !isManager) {
@@ -474,27 +458,18 @@ export function useProblemSolve() {
 		} catch (error: unknown) {
 			const message =
 				error instanceof Error ? error.message : "코드 제출에 실패했습니다.";
-			
-			// 백엔드에서 마감일/비활성화 에러 응답 처리
 			if (
-				message.includes("마감일") ||
 				message.includes("비활성화") ||
 				message.includes("제출할 수 없습니다")
 			) {
-				setIsDeadlinePassed(message.includes("마감일"));
-				if (message.includes("비활성화")) {
-					setIsAssignmentActive(false);
-					// 비활성화된 과제인 경우 알림 후 리다이렉트
-					alert(message);
-					setTimeout(() => {
-						navigate(`/sections/${sectionId}/course-assignments`);
-					}, 1000);
-					setIsSubmitting(false);
-					return;
-				}
+				setIsAssignmentActive(false);
 				alert(message);
+				setTimeout(() => {
+					navigate(`/sections/${sectionId}/course-assignments`);
+				}, 1000);
+				setIsSubmitting(false);
+				return;
 			}
-
 			setSubmissionResult({
 				status: "error",
 				message,
@@ -505,7 +480,7 @@ export function useProblemSolve() {
 		} finally {
 			setIsSubmitting(false);
 		}
-	}, [code, language, sectionId, problemId, clearSessionAfterSubmission, isDeadlinePassed, isAssignmentActive, navigate, userRole]);
+	}, [code, language, sectionId, problemId, clearSessionAfterSubmission, isAssignmentActive, navigate, userRole]);
 
 	const handleHorizontalDragEnd = useCallback((sizes: number[]) => {
 		setHorizontalSizes(sizes);

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx
@@ -150,11 +150,11 @@ export default function CourseAssignmentsPageView(
 																}
 															>
 																<S.ProblemTitle>{problem.title}</S.ProblemTitle>
-																<S.ProblemBadge $status={problem.status}>
+																<S.ProblemBadge $status={problem.status} $late={problem.status !== "NOT_SUBMITTED" && problem.isOnTime === false}>
 																	{problem.status === "ACCEPTED"
-																		? "정답"
+																		? (problem.isOnTime === false ? "지각 정답" : "정답")
 																		: problem.status === "SUBMITTED"
-																			? "제출"
+																			? (problem.isOnTime === false ? "지각 제출" : "제출")
 																			: "미제출"}
 																</S.ProblemBadge>
 															</S.AccordionProblemItem>

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts
@@ -114,7 +114,7 @@ export function useCourseAssignmentsPage() {
 								}) => {
 									const statusEntry = problemsStatus.find(
 										(s: { problemId: number }) => s.problemId === problem.id,
-									);
+									) as { problemId: number; status: string; isOnTime?: boolean } | undefined;
 									const raw = statusEntry
 										? statusEntry.status
 										: "NOT_SUBMITTED";
@@ -131,6 +131,7 @@ export function useCourseAssignmentsPage() {
 										description: problem.description,
 										submitted,
 										status: problemStatus,
+										isOnTime: statusEntry?.isOnTime,
 									};
 								},
 							);

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/styles.ts
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/styles.ts
@@ -293,19 +293,21 @@ export const ProblemTitle = styled.span`
   flex: 1;
 `;
 
-export const ProblemBadge = styled.span<{ $status: ProblemStatus }>`
+export const ProblemBadge = styled.span<{ $status: ProblemStatus; $late?: boolean }>`
   font-size: 12px;
   font-weight: 600;
   padding: 6px 14px;
   border-radius: 14px;
   background: ${(props) =>
-    props.$status === "ACCEPTED"
-      ? "#22C55E"
-      : props.$status === "SUBMITTED"
-        ? "#667EEA"
-        : "#EEEEEE"};
+    props.$late
+      ? "#EAB308"
+      : props.$status === "ACCEPTED"
+        ? "#22C55E"
+        : props.$status === "SUBMITTED"
+          ? "#667EEA"
+          : "#EEEEEE"};
   color: ${(props) =>
-    props.$status === "ACCEPTED" || props.$status === "SUBMITTED"
+    props.$status === "ACCEPTED" || props.$status === "SUBMITTED" || props.$late
       ? "#FFFFFF"
       : "#888888"};
 `;

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/types.ts
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/types.ts
@@ -6,6 +6,8 @@ export interface Problem {
 	description?: string;
 	submitted: boolean;
 	status: ProblemStatus;
+	/** 제출 시 마감일 이전 여부 (미제출이면 undefined) */
+	isOnTime?: boolean;
 }
 
 export interface Assignment {

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/CodeEditor/index.tsx
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/CodeEditor/index.tsx
@@ -56,14 +56,11 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 	isAssignmentActive = true,
 	userRole = null,
 }) => {
-	// 관리자/튜터는 비활성화된 과제도 제출 가능
+	// 관리자/튜터는 비활성화된 과제도 제출 가능; 마감일 지나면 지각 제출 가능(버튼 비활성화 안 함)
 	const isManager = userRole === "ADMIN" || userRole === "TUTOR";
-	const isSubmitDisabled = isSubmitting || isDeadlinePassed || (!isAssignmentActive && !isManager);
-	const disabledReason = isDeadlinePassed
-		? "과제 마감일이 지났습니다"
-		: !isAssignmentActive && !isManager
-			? "과제가 비활성화되었습니다"
-			: "";
+	const isSubmitDisabled = isSubmitting || (!isAssignmentActive && !isManager);
+	const disabledReason =
+		!isAssignmentActive && !isManager ? "과제가 비활성화되었습니다" : "";
 	const getBaseExtensions = () => [
 		bracketMatching(),
 		foldGutter(),

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx
@@ -122,8 +122,8 @@ const AssignmentListView: React.FC<AssignmentListViewProps> = ({
 										{assignment.problemCount || 0}개
 									</span>
 								</span>
-								<span className="tutor-assignment-meta-item">
-									<span className="tutor-meta-label">제출현황</span>
+								<span className="tutor-assignment-meta-item" title="해당 과제의 모든 문제를 1번 이상 제출한 학생 수 / 분반 전체 학생 수">
+									<span className="tutor-meta-label">모든 문제 완료 (명/전체)</span>
 									<span className="tutor-meta-value">
 										{submissionStats[assignment.id]
 											? `${submissionStats[assignment.id].submittedStudents}/${submissionStats[assignment.id].totalStudents}`

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx
@@ -85,7 +85,13 @@ const AssignmentTableView: React.FC<AssignmentTableViewProps> = ({
 						<th className="tutor-assignment-title-cell">과제 제목</th>
 						<th className="tutor-assignment-due-date-cell">마감일</th>
 						<th className="tutor-assignment-problem-count-cell">문제 수</th>
-						<th className="tutor-assignment-submission-cell">제출 현황</th>
+						<th
+							className="tutor-assignment-submission-cell"
+							title="해당 과제의 모든 문제를 1번 이상 제출한 학생 수 / 분반 전체 학생 수"
+						>
+							모든 문제 완료
+							<span className="tutor-column-subtitle">(명/전체)</span>
+						</th>
 						<th className="tutor-assignment-actions-cell">관리</th>
 					</tr>
 				</thead>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/styles.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/styles.ts
@@ -654,8 +654,18 @@ export const TableViewWrapper = styled.div`
     font-size: 0.95rem;
     color: #1e293b;
     font-weight: 600;
-    white-space: nowrap;
     text-align: right;
+  }
+
+  .tutor-assignment-submission-cell {
+    white-space: normal;
+  }
+  .tutor-assignment-submission-cell .tutor-column-subtitle {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 500;
+    opacity: 0.85;
+    margin-top: 2px;
   }
 
   .tutor-table-empty {

--- a/src/pages/TutorPage/Assignments/AssignmentStudentProgress/components/ProgressListView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentStudentProgress/components/ProgressListView.tsx
@@ -56,7 +56,10 @@ const ProgressListView: FC<ProgressListViewProps> = ({
 								<th>과제 제목</th>
 								<th>마감일</th>
 								<th>문제 수</th>
-								<th>제출 현황</th>
+								<th title="해당 과제의 모든 문제를 1번 이상 제출한 학생 수 / 분반 전체 학생 수">
+									모든 문제 완료
+									<S.ColumnSubtitle>(명/전체)</S.ColumnSubtitle>
+								</th>
 							</tr>
 						</thead>
 						<tbody>

--- a/src/pages/TutorPage/Assignments/AssignmentStudentProgress/styles.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentStudentProgress/styles.ts
@@ -842,6 +842,16 @@ export const AssignmentsTableContainer = styled.div`
 	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 `;
 
+export const ColumnSubtitle = styled.span`
+	display: block;
+	font-size: 0.7rem;
+	font-weight: 500;
+	opacity: 0.85;
+	text-transform: none;
+	letter-spacing: 0;
+	margin-top: 2px;
+`;
+
 export const AssignmentsTable = styled.table`
 	width: 100%;
 	border-collapse: collapse;

--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementAssignmentTable.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementAssignmentTable.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { FaCode, FaCheckCircle, FaTimesCircle } from "react-icons/fa";
+import { FaCode, FaCheckCircle, FaTimesCircle, FaExclamationTriangle } from "react-icons/fa";
 import * as S from "../styles";
 import type { StudentGradeRow, EditingGrade, AssignmentItem } from "../types";
 
@@ -48,6 +48,11 @@ export default function GradeManagementAssignmentTable({
 
 	return (
 		<S.CourseTableContainer>
+			<S.GradeLegend>
+				<span><FaCheckCircle style={{ color: "var(--color-success, #22c55e)", marginRight: 4 }} /> 제시간 제출</span>
+				<span><FaExclamationTriangle style={{ color: "var(--color-warning, #eab308)", marginRight: 4 }} /> 지각 제출</span>
+				<span><FaTimesCircle style={{ color: "var(--color-muted, #94a3b8)", marginRight: 4 }} /> 미제출</span>
+			</S.GradeLegend>
 			<S.CourseTableWithStickyRight>
 				<colgroup>
 					<col style={{ width: S.STICKY_COL_1_WIDTH }} />
@@ -154,20 +159,16 @@ export default function GradeManagementAssignmentTable({
 														(assignmentDue &&
 															new Date() > new Date(assignmentDue))) &&
 														(problem.submitted ? (
-															<S.SubmissionStatus $onTime={problem.isOnTime}>
+															<S.SubmissionStatus $onTime={problem.isOnTime} $late={!problem.isOnTime}>
 																{problem.isOnTime ? (
-																	<>
-																		<FaCheckCircle />
-																	</>
+																	<FaCheckCircle title="제시간 제출" />
 																) : (
-																	<>
-																		<FaTimesCircle />
-																	</>
+																	<FaExclamationTriangle title="지각 제출" />
 																)}
 															</S.SubmissionStatus>
 														) : (
-															<S.SubmissionStatus $onTime={false}>
-																<FaTimesCircle />
+															<S.SubmissionStatus $onTime={false} $late={false}>
+																<FaTimesCircle title="미제출" />
 															</S.SubmissionStatus>
 														))}
 												</S.ScoreRow>

--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementCourseTable.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementCourseTable.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FaCheckCircle, FaTimesCircle, FaCode } from "react-icons/fa";
+import { FaCheckCircle, FaTimesCircle, FaExclamationTriangle, FaCode } from "react-icons/fa";
 import * as S from "../styles";
 import type {
 	CourseGradesData,
@@ -64,6 +64,13 @@ export default function GradeManagementCourseTable({
 }: GradeManagementCourseTableProps) {
 	return (
 		<S.CourseTableContainer>
+			{!courseLoading && courseGrades?.items?.length && filteredCourseStudents.length > 0 && (
+				<S.GradeLegend>
+					<span><FaCheckCircle style={{ color: "#22c55e", marginRight: 4 }} /> 제시간 제출</span>
+					<span><FaExclamationTriangle style={{ color: "#eab308", marginRight: 4 }} /> 지각 제출</span>
+					<span><FaTimesCircle style={{ color: "#94a3b8", marginRight: 4 }} /> 미제출</span>
+				</S.GradeLegend>
+			)}
 			{courseLoading ? (
 				<S.LoadingContainer>
 					<S.LoadingSpinner />
@@ -259,20 +266,17 @@ export default function GradeManagementCourseTable({
 																				(problemGrade?.submitted ? (
 																					<S.SubmissionStatus
 																						$onTime={problemGrade.isOnTime}
+																						$late={!problemGrade.isOnTime}
 																					>
 																						{problemGrade.isOnTime ? (
-																							<>
-																								<FaCheckCircle />
-																							</>
+																							<FaCheckCircle title="제시간 제출" />
 																						) : (
-																							<>
-																								<FaTimesCircle />
-																							</>
+																							<FaExclamationTriangle title="지각 제출" />
 																						)}
 																					</S.SubmissionStatus>
 																				) : (
-																					<S.SubmissionStatus $onTime={false}>
-																						<FaTimesCircle />
+																					<S.SubmissionStatus $onTime={false} $late={false}>
+																						<FaTimesCircle title="미제출" />
 																					</S.SubmissionStatus>
 																				))}
 																		</S.ScoreRow>
@@ -335,20 +339,17 @@ export default function GradeManagementCourseTable({
 																			(problemGrade?.submitted ? (
 																				<S.SubmissionStatus
 																					$onTime={problemGrade.isOnTime}
+																					$late={!problemGrade.isOnTime}
 																				>
 																					{problemGrade.isOnTime ? (
-																						<>
-																							<FaCheckCircle />
-																						</>
+																						<FaCheckCircle title="제시간 제출" />
 																					) : (
-																						<>
-																							<FaTimesCircle />
-																						</>
+																						<FaExclamationTriangle title="지각 제출" />
 																					)}
 																				</S.SubmissionStatus>
 																			) : (
-																				<S.SubmissionStatus $onTime={false}>
-																					<FaTimesCircle />
+																				<S.SubmissionStatus $onTime={false} $late={false}>
+																					<FaTimesCircle title="미제출" />
 																				</S.SubmissionStatus>
 																			))}
 																	</S.ScoreRow>

--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementQuizTable.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementQuizTable.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { FaCode, FaCheckCircle, FaTimesCircle } from "react-icons/fa";
+import { FaCode, FaCheckCircle, FaTimesCircle, FaExclamationTriangle } from "react-icons/fa";
 import * as S from "../styles";
 import type { StudentGradeRow, QuizItem, EditingGrade } from "../types";
 
@@ -52,6 +52,11 @@ export default function GradeManagementQuizTable({
 
 	return (
 		<S.CourseTableContainer>
+			<S.GradeLegend>
+				<span><FaCheckCircle style={{ color: "#22c55e", marginRight: 4 }} /> 제시간 제출</span>
+				<span><FaExclamationTriangle style={{ color: "#eab308", marginRight: 4 }} /> 지각 제출</span>
+				<span><FaTimesCircle style={{ color: "#94a3b8", marginRight: 4 }} /> 미제출</span>
+			</S.GradeLegend>
 			<S.CourseTableWithStickyRight>
 				<colgroup>
 					<col style={{ width: S.STICKY_COL_1_WIDTH }} />
@@ -139,20 +144,16 @@ export default function GradeManagementQuizTable({
 													(selectedQuiz?.endTime &&
 														new Date() > new Date(selectedQuiz.endTime))) &&
 													(problem.submitted ? (
-														<S.SubmissionStatus $onTime={problem.isOnTime}>
+														<S.SubmissionStatus $onTime={problem.isOnTime} $late={!problem.isOnTime}>
 															{problem.isOnTime ? (
-																<>
-																	<FaCheckCircle />
-																</>
+																<FaCheckCircle title="제시간 제출" />
 															) : (
-																<>
-																	<FaTimesCircle /> 기한 초과
-																</>
+																<FaExclamationTriangle title="지각 제출" />
 															)}
 														</S.SubmissionStatus>
 													) : (
-														<S.SubmissionStatus $onTime={false}>
-															<FaTimesCircle />
+														<S.SubmissionStatus $onTime={false} $late={false}>
+															<FaTimesCircle title="미제출" />
 														</S.SubmissionStatus>
 													))}
 											</S.ScoreRow>

--- a/src/pages/TutorPage/Grades/GradeManagement/styles.ts
+++ b/src/pages/TutorPage/Grades/GradeManagement/styles.ts
@@ -776,12 +776,26 @@ export const SubmissionInfo = styled.div`
   margin-top: 0.25rem;
 `;
 
-export const SubmissionStatus = styled.span<{ $onTime?: boolean }>`
+export const SubmissionStatus = styled.span<{ $onTime?: boolean; $late?: boolean }>`
   display: flex;
   align-items: center;
   gap: 0.25rem;
   font-weight: 600;
-  color: ${(p) => (p.$onTime ? "#10b981" : "#ef4444")};
+  color: ${(p) =>
+    p.$onTime ? "#10b981" : p.$late ? "#eab308" : "#94a3b8"};
+`;
+
+export const GradeLegend = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+  font-size: 0.875rem;
+  color: #64748b;
+  & span {
+    display: inline-flex;
+    align-items: center;
+  }
 `;
 
 export const SubmissionTime = styled.span`
@@ -880,7 +894,7 @@ export const TdTotalCell = styled.td`
 `;
 
 export const CourseTableContainer = styled(TableContainer)`
-  margin-top: 1.5rem;
+  margin-top: 1rem;
 `;
 
 export const CourseTable = styled(Table)``;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #135 

### 1. 문제 제목 "(복사본)" 유지
- **problemUtils.ts**: `removeCopyLabel`에서 "(복사본)" 제거하지 않고 trim만 수행
- **ProblemEdit**: 편집 시 제목은 DB 값 우선 (`problem?.title ?? parsedData?.title`)

### 2. 문제 생성/편집 제출 검증 및 로딩
- **Create**: 제목·시간·메모리·설명·테스트케이스 필수 검증, 누락 항목 alert, 통과 시 즉시 로딩으로 중복 제출 방지
- **Edit**: `enableFullEdit`일 때 설명·테스트케이스 필수 검증 후 제출, 통과 시에만 `setSubmitting(true)`

### 3. 입력 형식·출력 형식·예제 중복 및 편집 반영
- **problemEditUtils.ts**: `parseDescriptionSections`, `descriptionForPreview`, `stripDuplicateInputOutputExample` (표시 시 중복 블록 제거)
- **useProblemEdit.ts**: 편집 로드 시 파싱 결과로 `inputFormat`, `outputFormat`, `sampleInputs` 채움, `descriptionText`는 본문만 저장
- 저장 시 `getFullDescriptionForBackend()`에서 본문 + 입력/출력/예제 블록 **한 번만** 붙이도록 처리
- 문제 관리/상세/학생용 설명 등에서 API로 받은 description에 `stripDuplicateInputOutputExample` 적용

### 4. 편집 시 예제 입출력 입력 안정화
- **ProblemEditSampleInputsSection.tsx**: 예제 아이템 `key`를 `sample-${idx}`만 사용 (입력값 제거로 리마운트·포커스 손실 방지)
- **useProblemEdit.ts**: `handleSampleInputChange`를 함수형 업데이트(`setFormData(prev => ...)`)로 변경

### 5. 미리보기
- **useProblemEdit.ts**: `getFullPreviewProps()` — 전체 설명(본문+입력 형식+출력 형식+예제) 한 덩어리로 표시, `stripDuplicateInputOutputExample` 적용
- **ProblemEditDescriptionSection.tsx**: 미리보기에 `getFullPreviewProps()` 사용, `descriptionOnly: true`

### 6. 지각 제출 허용 (마감 후에도 제출 가능)
- **useProblemSolve.ts**: 마감일 지났을 때 제출 차단 및 관련 alert 제거, 에러 처리에서 "마감일" 분기 제거
- **CodeEditor (CodingQuizSolvePage)**: `isSubmitDisabled`에서 `isDeadlinePassed` 제거 → 마감 후에도 제출 버튼 활성

### 7. 성적 매기기 — 제시간/지각/미제출 구분
- **GradeManagementAssignmentTable, GradeManagementCourseTable, GradeManagementQuizTable**:  
  - ○(FaCheckCircle) 제시간 제출, △(FaExclamationTriangle) 지각 제출, ×(FaTimesCircle) 미제출
  - 테이블 위에 범례 추가: "○ 제시간 제출, △ 지각 제출, × 미제출"
- **styles.ts**: `SubmissionStatus`에 `$late`, `GradeLegend` 스타일 추가

### 8. 학생 과제 목록 — 지각 정답/지각 제출 표시
- **types.ts**: `Problem`에 `isOnTime?: boolean` 추가
- **useCourseAssignmentsPage.ts**: API 응답의 `isOnTime`을 문제 객체에 매핑
- **CourseAssignmentsPageView.tsx**: ACCEPTED + `isOnTime === false` → "지각 정답", SUBMITTED + `isOnTime === false` → "지각 제출"
- **CourseAssignmentsPage styles**: `ProblemBadge`에 `$late` 스타일 (노란 배경)

### 9. 제출 현황 — "모든 문제 완료" 명시 및 인원 수 수정
- **ProgressListView** (과제별 풀이 현황):  
  - 컬럼 헤더 "제출 현황" → **"모든 문제 완료"** + 부제 **(명/전체)**, 툴팁으로 의미 설명
  - `ColumnSubtitle` 스타일 추가
- **AssignmentTableView, AssignmentListView** (tutor/assignments/section/:id):  
  - 동일하게 **"모든 문제 완료 (명/전체)"** 라벨 및 툴팁 적용
  - **styles.ts**: `.tutor-column-subtitle`, `.tutor-assignment-submission-cell` 스타일 추가