### PR TITLE
feat(problem): 문제 가져오기 페이지 추가 및 내보내기 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ import ProblemSetManagement from "./pages/TutorPage/Problems/ProblemSetManagemen
 import ProblemSetEdit from "./pages/TutorPage/Problems/ProblemSetEdit";
 import ProblemCreate from "./pages/TutorPage/Problems/ProblemCreate";
 import ProblemEdit from "./pages/TutorPage/Problems/ProblemEdit";
+import ProblemImport from "./pages/TutorPage/Problems/ProblemImport";
 import SettingsPage from "./pages/TutorPage/Settings/SettingsPage";
 import CodingTestManagement from "./pages/TutorPage/CodingTests/CodingTestManagement";
 // SuperAdmin (시스템 관리자)
@@ -316,6 +317,16 @@ const App: React.FC = () => {
 							<AdminRoute>
 								<TutorAccessGate>
 									<ProblemManagement />
+								</TutorAccessGate>
+							</AdminRoute>
+						}
+					/>
+					<Route
+						path="/tutor/problems/import"
+						element={
+							<AdminRoute>
+								<TutorAccessGate>
+									<ProblemImport />
 								</TutorAccessGate>
 							</AdminRoute>
 						}

--- a/src/pages/TutorPage/Problems/ProblemImport/components/ProblemImportView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemImport/components/ProblemImportView.tsx
@@ -1,0 +1,874 @@
+import React, { useState, useCallback, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
+import TutorLayout from "../../../../../layouts/TutorLayout";
+import LoadingSpinner from "../../../../../components/UI/LoadingSpinner";
+import * as S from "../styles";
+import * as PCS from "../../ProblemCreate/styles";
+import ProblemPreview from "../../ProblemCreate/components/ProblemPreview";
+import type { useProblemImport } from "../hooks/useProblemImport";
+import type { EditableProblem } from "../types";
+import type { TestCaseDto } from "../../ProblemCreate/types";
+
+type HookReturn = ReturnType<typeof useProblemImport>;
+
+function parseSampleInputs(json: string | undefined): { input: string; output: string }[] {
+	try {
+		const arr = json ? JSON.parse(json) : [];
+		return Array.isArray(arr) ? arr : [];
+	} catch {
+		return [];
+	}
+}
+
+function parseTags(json: string | undefined): string[] {
+	try {
+		const arr = json ? JSON.parse(json) : [];
+		return Array.isArray(arr) ? arr : [];
+	} catch {
+		return [];
+	}
+}
+
+export default function ProblemImportView(d: HookReturn) {
+	return (
+		<TutorLayout>
+			{d.isUploading &&
+				createPortal(
+					<div
+						style={{
+							position: "fixed",
+							inset: 0,
+							backgroundColor: "rgba(0,0,0,0.5)",
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							zIndex: 99999,
+							pointerEvents: "auto",
+						}}
+					>
+						<div
+							style={{
+								background: "white",
+								padding: "2rem",
+								borderRadius: "12px",
+								boxShadow: "0 8px 24px rgba(0,0,0,0.2)",
+							}}
+						>
+							<LoadingSpinner message="문제 업로드 중..." />
+						</div>
+					</div>,
+					document.body,
+				)}
+
+			<S.Container>
+				<S.PageHeader>
+					<S.PageTitle>문제 가져오기</S.PageTitle>
+					<S.BackButton type="button" onClick={d.goBack}>
+						← 뒤로
+					</S.BackButton>
+				</S.PageHeader>
+
+				{d.parseError && <S.ErrorMessage>{d.parseError}</S.ErrorMessage>}
+
+				<S.Layout>
+					<S.MainPanel>
+						{d.editableProblems.length === 0 ? (
+							<S.EmptyState>
+								{d.isParsing
+									? "ZIP 파일을 파싱하는 중..."
+									: "오른쪽에서 ZIP 파일을 선택해 주세요."}
+							</S.EmptyState>
+						) : !d.selectedProblem ? (
+							<S.EmptyState>문제를 선택해 주세요.</S.EmptyState>
+						) : (
+							<EditForm
+								problem={d.selectedProblem}
+								onUpdate={(updates) =>
+									d.updateProblem(d.selectedIndex, updates)
+								}
+								onApprove={() => d.toggleApproved(d.selectedIndex)}
+								isApproved={d.approvedSet.has(d.selectedIndex)}
+							/>
+						)}
+					</S.MainPanel>
+
+					<S.Sidebar>
+						<input
+							ref={d.fileInputRef}
+							type="file"
+							accept=".zip"
+							onChange={d.handleFileChange}
+							style={{ display: "none" }}
+						/>
+						<S.FileSelectButton
+							type="button"
+							onClick={d.selectFile}
+							disabled={d.isParsing}
+						>
+							{d.isParsing ? "파싱 중..." : "ZIP 파일 선택"}
+						</S.FileSelectButton>
+						{d.zipFile && !d.isParsing && (
+							<div style={{ fontSize: "0.85rem", color: "#64748b" }}>
+								{d.zipFile.name}
+							</div>
+						)}
+
+						{d.editableProblems.length > 0 && (
+							<>
+								<div
+									style={{
+										display: "flex",
+										alignItems: "center",
+										justifyContent: "space-between",
+									}}
+								>
+									<span style={{ fontSize: "0.9rem", fontWeight: 500 }}>
+										문제 목록
+									</span>
+									<S.ApproveAllButton
+										type="button"
+										onClick={d.approveAll}
+									>
+										전체 승인
+									</S.ApproveAllButton>
+								</div>
+								<S.ProblemList>
+									{d.editableProblems.map((p, i) => (
+										<S.ProblemListItem
+											key={p._index}
+											$selected={d.selectedIndex === i}
+											onClick={() => d.setSelectedIndex(i)}
+										>
+											<S.ListCheckbox
+												type="checkbox"
+												checked={d.approvedSet.has(i)}
+												onChange={(e) => {
+													e.stopPropagation();
+													d.toggleApproved(i);
+												}}
+											/>
+											<S.ListTitle>{p.title || p._filename}</S.ListTitle>
+										</S.ProblemListItem>
+									))}
+								</S.ProblemList>
+								<S.UploadButton
+									type="button"
+									onClick={d.uploadApproved}
+									disabled={d.approvedSet.size === 0}
+								>
+									승인된 문제 업로드 ({d.approvedSet.size}개)
+								</S.UploadButton>
+							</>
+						)}
+					</S.Sidebar>
+				</S.Layout>
+			</S.Container>
+
+			{d.uploadResultModal &&
+				createPortal(
+					<S.ModalOverlay onClick={() => d.closeResultModal()}>
+						<S.ModalContent onClick={(e) => e.stopPropagation()}>
+							<S.ModalTitle $success={d.uploadResultModal.success}>
+								{d.uploadResultModal.success ? "업로드 완료" : "업로드 실패"}
+							</S.ModalTitle>
+							<S.ModalMessage>{d.uploadResultModal.message}</S.ModalMessage>
+							<S.ModalButton onClick={() => d.closeResultModal()}>
+								확인
+							</S.ModalButton>
+						</S.ModalContent>
+					</S.ModalOverlay>,
+					document.body,
+				)}
+		</TutorLayout>
+	);
+}
+
+function EditForm({
+	problem,
+	onUpdate,
+	onApprove,
+	isApproved,
+}: {
+	problem: import("../types").EditableProblem;
+	onUpdate: (updates: Partial<import("../types").EditableProblem>) => void;
+	onApprove: () => void;
+	isApproved: boolean;
+}) {
+	const tags = parseTags(problem.tags);
+	const samples = parseSampleInputs(problem.sampleInputs);
+	const testcases = problem.testcases ?? [];
+
+	const [currentTag, setCurrentTag] = useState("");
+	const [previewMode, setPreviewMode] = useState<"descriptionOnly" | "full">("full");
+	const [previewExpanded, setPreviewExpanded] = useState(true);
+	const descriptionRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const el = descriptionRef.current;
+		if (el && el.innerText !== (problem.description ?? "")) {
+			el.innerText = problem.description ?? "";
+		}
+	}, [problem._index]);
+
+	const syncDescription = useCallback(
+		(plain: string) => {
+			onUpdate({ description: plain });
+		},
+		[onUpdate],
+	);
+
+	const insertMarkdownText = useCallback(
+		(text: string) => {
+			const el = descriptionRef.current;
+			if (!el) return;
+			el.focus();
+			document.execCommand("insertText", false, text);
+			const plain = el.innerText || el.textContent || "";
+			syncDescription(plain);
+		},
+		[syncDescription],
+	);
+
+	const wrapWithMarkdown = useCallback(
+		(syntax: string) => {
+			const el = descriptionRef.current;
+			if (!el) return;
+			el.focus();
+			const selection = window.getSelection();
+			if (selection && !selection.isCollapsed && selection.rangeCount > 0) {
+				const selectedText = selection.getRangeAt(0).toString();
+				document.execCommand("insertText", false, `${syntax}${selectedText}${syntax}`);
+			} else {
+				document.execCommand("insertText", false, `${syntax}${syntax}`);
+			}
+			const plain = el.innerText || el.textContent || "";
+			syncDescription(plain);
+		},
+		[syncDescription],
+	);
+
+	const insertMarkdownHeading = useCallback(
+		(headingValue: string) => {
+			const el = descriptionRef.current;
+			if (!el) return;
+			el.focus();
+			const levelMap: Record<string, string> = {
+				h1: "# ",
+				h2: "## ",
+				h3: "### ",
+				h4: "#### ",
+				h5: "##### ",
+				h6: "###### ",
+				p: "",
+			};
+			const prefix = levelMap[headingValue] ?? "";
+			if (prefix) {
+				document.execCommand("insertText", false, prefix);
+			}
+			const plain = el.innerText || el.textContent || "";
+			syncDescription(plain);
+		},
+		[syncDescription],
+	);
+
+	const getPreviewProps = useCallback(() => {
+		const desc = problem.description ?? "";
+		const normalized = desc.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		const match = normalized.match(/(\n|^)\s*##\s*입력\s*형식\s*[\n\r]/);
+		const mainOnly =
+			match && match.index != null ? normalized.slice(0, match.index).trim() : desc;
+		if (previewMode === "descriptionOnly") {
+			return {
+				title: problem.title ?? "",
+				description: mainOnly,
+				inputFormat: "",
+				outputFormat: "",
+				sampleInputs: [] as { input: string; output: string }[],
+			};
+		}
+		return {
+			title: problem.title ?? "",
+			description: mainOnly,
+			inputFormat: problem.inputFormat ?? "",
+			outputFormat: problem.outputFormat ?? "",
+			sampleInputs: samples,
+		};
+	}, [problem, previewMode, samples]);
+
+	const handleTagAdd = useCallback(() => {
+		const t = currentTag.trim();
+		if (!t) return;
+		const next = [...tags, t];
+		onUpdate({ tags: JSON.stringify(next) });
+		setCurrentTag("");
+	}, [currentTag, tags, onUpdate]);
+
+	const handleTagRemove = useCallback(
+		(tag: string) => {
+			onUpdate({ tags: JSON.stringify(tags.filter((x) => x !== tag)) });
+		},
+		[tags, onUpdate],
+	);
+
+	const handleTagKeyPress = useCallback(
+		(e: React.KeyboardEvent) => {
+			if (e.key === "Enter") {
+				e.preventDefault();
+				handleTagAdd();
+			}
+		},
+		[handleTagAdd],
+	);
+
+	const addSampleInput = useCallback(() => {
+		onUpdate({ sampleInputs: JSON.stringify([...samples, { input: "", output: "" }]) });
+	}, [samples, onUpdate]);
+
+	const removeSampleInput = useCallback(
+		(idx: number) => {
+			onUpdate({
+				sampleInputs: JSON.stringify(samples.filter((_, i) => i !== idx)),
+			});
+		},
+		[samples, onUpdate],
+	);
+
+	const handleSampleInputChange = useCallback(
+		(idx: number, field: "input" | "output", value: string) => {
+			const next = [...samples];
+			next[idx] = { ...next[idx], [field]: value };
+			onUpdate({ sampleInputs: JSON.stringify(next) });
+		},
+		[samples, onUpdate],
+	);
+
+	const updateTestCase = useCallback(
+		(idx: number, updates: Partial<TestCaseDto>) => {
+			const next = testcases.map((tc, i) =>
+				i === idx ? { ...tc, ...updates } : tc,
+			);
+			onUpdate({ testcases: next });
+		},
+		[testcases, onUpdate],
+	);
+
+	const removeTestCase = useCallback(
+		(idx: number) => {
+			onUpdate({ testcases: testcases.filter((_, i) => i !== idx) });
+		},
+		[testcases, onUpdate],
+	);
+
+	const addTestCase = useCallback(() => {
+		onUpdate({
+			testcases: [
+				...testcases,
+				{ name: "1", input: "", output: "", type: "secret" },
+			],
+		});
+	}, [testcases, onUpdate]);
+
+	return (
+		<S.PreviewDrawerWrapper>
+			<div style={{ flex: 1, minWidth: 0, position: "relative" }}>
+				<PCS.FormGrid style={{ minWidth: 0 }}>
+				{/* 문제 제목, 난이도, 태그 */}
+			<PCS.FormSection>
+				<PCS.Label>문제 제목</PCS.Label>
+				<PCS.Input
+					type="text"
+					value={problem.title}
+					onChange={(e) => onUpdate({ title: e.target.value })}
+					placeholder="문제 제목을 입력하세요"
+				/>
+			</PCS.FormSection>
+
+			<PCS.FormRow>
+				<PCS.FormSection>
+					<PCS.Label>난이도</PCS.Label>
+					<PCS.Select
+						value={problem.difficulty ?? "1"}
+						onChange={(e) => onUpdate({ difficulty: e.target.value })}
+					>
+						<option value="1">Level 1</option>
+						<option value="2">Level 2</option>
+						<option value="3">Level 3</option>
+					</PCS.Select>
+				</PCS.FormSection>
+				<PCS.FormSection>
+					<PCS.Label>태그</PCS.Label>
+					<PCS.TagInputWrapper>
+						<PCS.Input
+							type="text"
+							value={currentTag}
+							onChange={(e) => setCurrentTag(e.target.value)}
+							onKeyDown={handleTagKeyPress}
+							placeholder="태그 입력 후 Enter"
+						/>
+						<PCS.TagAddButton type="button" onClick={handleTagAdd}>
+							추가
+						</PCS.TagAddButton>
+					</PCS.TagInputWrapper>
+					<PCS.Tags>
+						{tags.map((tag, idx) => (
+							<PCS.Tag key={idx}>
+								{tag}
+								<PCS.TagRemove
+									type="button"
+									onClick={() => handleTagRemove(tag)}
+								>
+									×
+								</PCS.TagRemove>
+							</PCS.Tag>
+						))}
+					</PCS.Tags>
+				</PCS.FormSection>
+			</PCS.FormRow>
+
+			{/* 시간 제한, 메모리 제한 */}
+			<PCS.FormRow>
+				<PCS.FormSection>
+					<PCS.Label>시간 제한 (초)</PCS.Label>
+					<PCS.Input
+						type="number"
+						value={problem.timeLimit ?? ""}
+						onChange={(e) => onUpdate({ timeLimit: e.target.value })}
+						min={0}
+						step={0.1}
+						placeholder="예: 2.0"
+					/>
+				</PCS.FormSection>
+				<PCS.FormSection>
+					<PCS.Label>메모리 제한 (MB)</PCS.Label>
+					<PCS.Input
+						type="number"
+						value={problem.memoryLimit ?? ""}
+						onChange={(e) => onUpdate({ memoryLimit: e.target.value })}
+						min={0}
+						placeholder="예: 256"
+					/>
+				</PCS.FormSection>
+			</PCS.FormRow>
+
+			{/* 문제 설명 */}
+			<PCS.FormSection as={PCS.DescriptionSection}>
+				<div
+					style={{
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "space-between",
+						gap: "0.75rem",
+						marginBottom: "0.5rem",
+					}}
+				>
+					<PCS.Label>문제 설명</PCS.Label>
+					{!previewExpanded && (
+						<S.PreviewDrawerToggle
+							type="button"
+							onClick={() => setPreviewExpanded(true)}
+							title="미리보기 펼치기"
+						>
+							▶ 미리보기
+						</S.PreviewDrawerToggle>
+					)}
+				</div>
+				<div
+					style={{
+						border: "2px solid #e2e8f0",
+						borderRadius: 8,
+						overflow: "hidden",
+					}}
+				>
+					<PCS.EditorWrapper>
+						<PCS.EditorToolbar>
+							<PCS.HeadingSelect
+								onChange={(e) => {
+									const v = e.target.value;
+									if (v) {
+										insertMarkdownHeading(v);
+										e.target.value = "";
+									}
+								}}
+								title="제목 스타일 (# 삽입)"
+							>
+								<option value="">제목 스타일</option>
+								<option value="h1">제목 1 (#)</option>
+								<option value="h2">제목 2 (##)</option>
+								<option value="h3">제목 3 (###)</option>
+								<option value="h4">제목 4 (####)</option>
+							</PCS.HeadingSelect>
+							<PCS.HeadingSelect
+								onChange={(e) => {
+									const size = e.target.value;
+									if (!size) return;
+									const el = descriptionRef.current;
+									if (!el) {
+										e.target.value = "";
+										return;
+									}
+									el.focus();
+									const openTag = `<span style="font-size: ${size}">`;
+									const closeTag = `</span>`;
+									const sel = window.getSelection();
+									if (sel && !sel.isCollapsed && sel.rangeCount > 0) {
+										const selectedText = sel.getRangeAt(0).toString();
+										document.execCommand(
+											"insertText",
+											false,
+											`${openTag}${selectedText}${closeTag}`,
+										);
+									} else {
+										document.execCommand("insertText", false, `${openTag}${closeTag}`);
+									}
+									const plain = el.innerText || el.textContent || "";
+									syncDescription(plain);
+									e.target.value = "";
+								}}
+								title="글자 크기"
+							>
+								<option value="">글자 크기</option>
+								<option value="0.75em">작게 (0.75x)</option>
+								<option value="1em">기본 (1x)</option>
+								<option value="1.25em">크게 (1.25x)</option>
+								<option value="1.5em">더 크게 (1.5x)</option>
+								<option value="2em">매우 크게 (2x)</option>
+							</PCS.HeadingSelect>
+							<PCS.ToolbarDivider />
+							<PCS.ToolbarButton
+								type="button"
+								onClick={() => wrapWithMarkdown("**")}
+								title="Bold (**텍스트**)"
+							>
+								<strong>B</strong>
+							</PCS.ToolbarButton>
+							<PCS.ToolbarButton
+								type="button"
+								onClick={() => wrapWithMarkdown("*")}
+								title="Italic (*텍스트*)"
+							>
+								<em>I</em>
+							</PCS.ToolbarButton>
+							<PCS.ToolbarButton
+								type="button"
+								onClick={() => wrapWithMarkdown("`")}
+								title="인라인 코드 (`코드`)"
+							>
+								{"</>"}
+							</PCS.ToolbarButton>
+							<PCS.ToolbarDivider />
+							<PCS.ToolbarButton
+								type="button"
+								onClick={() => insertMarkdownText("\n- ")}
+								title="글머리 기호 목록"
+							>
+								•
+							</PCS.ToolbarButton>
+							<PCS.ToolbarButton
+								type="button"
+								onClick={() => insertMarkdownText("\n1. ")}
+								title="번호 매기기 목록"
+							>
+								1.
+							</PCS.ToolbarButton>
+							<PCS.ToolbarDivider />
+							<PCS.ToolbarButton
+								type="button"
+								onClick={() => insertMarkdownText("\n> ")}
+								title="인용문 (> 텍스트)"
+							>
+								"
+							</PCS.ToolbarButton>
+							<PCS.ToolbarButton
+								type="button"
+								onClick={() => insertMarkdownText("\n```\n코드\n```\n")}
+								title="코드 블록"
+							>
+								&lt;&gt;
+							</PCS.ToolbarButton>
+							<PCS.ToolbarButton
+								type="button"
+								onClick={() => insertMarkdownText("\n---\n")}
+								title="구분선"
+							>
+								—
+							</PCS.ToolbarButton>
+						</PCS.EditorToolbar>
+						<PCS.TextEditor
+							ref={descriptionRef}
+							contentEditable
+							suppressContentEditableWarning
+							data-placeholder="마크다운으로 문제 설명을 입력하세요 (예: # 제목, **굵게**, \`\`\`코드\`\`\`)"
+							onPaste={(e) => {
+								e.preventDefault();
+								const paste = e.clipboardData?.getData("text") ?? "";
+								const selection = window.getSelection();
+								if (!selection?.rangeCount) return;
+								const range = selection.getRangeAt(0);
+								range.deleteContents();
+								range.insertNode(document.createTextNode(paste));
+								range.collapse(false);
+								selection.removeAllRanges();
+								selection.addRange(range);
+								const plain =
+									descriptionRef.current?.innerText ||
+									descriptionRef.current?.textContent ||
+									"";
+								syncDescription(plain);
+							}}
+							onInput={(e) => {
+								const plain =
+									e.currentTarget?.innerText || e.currentTarget?.textContent || "";
+								syncDescription(plain);
+							}}
+							onBlur={(e) => {
+								const plain =
+									e.currentTarget?.innerText || e.currentTarget?.textContent || "";
+								syncDescription(plain);
+							}}
+							onKeyDown={(e) => {
+								if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+									e.preventDefault();
+									document.execCommand("undo", false);
+								}
+								if (
+									(e.ctrlKey || e.metaKey) &&
+									(e.key === "y" || (e.key === "z" && e.shiftKey))
+								) {
+									e.preventDefault();
+									document.execCommand("redo", false);
+								}
+							}}
+						/>
+					</PCS.EditorWrapper>
+				</div>
+			</PCS.FormSection>
+
+			{/* 입력/출력 형식 */}
+			<PCS.FormRow>
+				<PCS.FormSection>
+					<PCS.Label>입력 형식</PCS.Label>
+					<PCS.Textarea
+						value={problem.inputFormat ?? ""}
+						onChange={(e) => onUpdate({ inputFormat: e.target.value })}
+						rows={4}
+						placeholder="입력 형식을 설명하세요"
+					/>
+				</PCS.FormSection>
+				<PCS.FormSection>
+					<PCS.Label>출력 형식</PCS.Label>
+					<PCS.Textarea
+						value={problem.outputFormat ?? ""}
+						onChange={(e) => onUpdate({ outputFormat: e.target.value })}
+						rows={4}
+						placeholder="출력 형식을 설명하세요"
+					/>
+				</PCS.FormSection>
+			</PCS.FormRow>
+
+			{/* 예제 입출력 (추가/삭제 포함) */}
+			<PCS.FormSection>
+				<PCS.Label>예제 입출력</PCS.Label>
+				{samples.map((sample, idx) => (
+					<PCS.SampleItem key={idx}>
+						<PCS.SampleItemHeader>
+							<span>예제 #{idx + 1}</span>
+							{samples.length > 1 && (
+								<PCS.SampleRemove
+									type="button"
+									onClick={() => removeSampleInput(idx)}
+								>
+									삭제
+								</PCS.SampleRemove>
+							)}
+						</PCS.SampleItemHeader>
+						<PCS.SampleGrid>
+							<div>
+								<PCS.SampleLabel>입력</PCS.SampleLabel>
+								<PCS.Textarea
+									value={sample.input}
+									onChange={(e) =>
+										handleSampleInputChange(idx, "input", e.target.value)
+									}
+									rows={3}
+									placeholder="예제 입력"
+								/>
+							</div>
+							<div>
+								<PCS.SampleLabel>출력</PCS.SampleLabel>
+								<PCS.Textarea
+									value={sample.output}
+									onChange={(e) =>
+										handleSampleInputChange(idx, "output", e.target.value)
+									}
+									rows={3}
+									placeholder="예제 출력"
+								/>
+							</div>
+						</PCS.SampleGrid>
+					</PCS.SampleItem>
+				))}
+				<PCS.AddSampleButton type="button" onClick={addSampleInput}>
+					+ 예제 추가
+				</PCS.AddSampleButton>
+			</PCS.FormSection>
+
+			{/* 테스트케이스 (이름, 타입, 입력, 출력 편집, 삭제) */}
+			<PCS.FormSection>
+				<PCS.Label>테스트케이스</PCS.Label>
+				{testcases.length > 0 ? (
+					<PCS.ParsedTestcasesSection>
+						<PCS.ParsedTestcases>
+							{testcases.map((tc, idx) => (
+								<PCS.ParsedTestcaseItem key={idx}>
+									<PCS.ParsedTestcaseHeader>
+										<span>
+											<PCS.Input
+												type="text"
+												value={tc.name}
+												onChange={(e) =>
+													updateTestCase(idx, { name: e.target.value })
+												}
+												placeholder="이름"
+												style={{
+													width: "120px",
+													padding: "0.35rem 0.5rem",
+													fontSize: "0.9rem",
+												}}
+												onClick={(e) => e.stopPropagation()}
+											/>
+											<select
+												value={tc.type ?? "secret"}
+												onChange={(e) =>
+													updateTestCase(idx, {
+														type: e.target.value as "sample" | "secret",
+													})
+												}
+												style={{
+													marginLeft: 8,
+													padding: "0.35rem 0.5rem",
+													borderRadius: 4,
+													border: "1px solid #cbd5e1",
+													fontSize: "0.85rem",
+												}}
+											>
+												<option value="sample">샘플</option>
+												<option value="secret">비밀</option>
+											</select>
+										</span>
+										<PCS.TestcaseRemove
+											type="button"
+											onClick={() => removeTestCase(idx)}
+										>
+											×
+										</PCS.TestcaseRemove>
+									</PCS.ParsedTestcaseHeader>
+									<PCS.ParsedTestcaseContent>
+										<div>
+											<strong>입력:</strong>
+											<PCS.Textarea
+												value={tc.input ?? ""}
+												onChange={(e) =>
+													updateTestCase(idx, { input: e.target.value })
+												}
+												rows={3}
+												placeholder="(없음)"
+												style={{
+													fontFamily: "monospace",
+													fontSize: "0.85rem",
+													marginTop: 4,
+												}}
+											/>
+										</div>
+										<div>
+											<strong>출력:</strong>
+											<PCS.Textarea
+												value={tc.output ?? ""}
+												onChange={(e) =>
+													updateTestCase(idx, { output: e.target.value })
+												}
+												rows={3}
+												placeholder="(없음)"
+												style={{
+													fontFamily: "monospace",
+													fontSize: "0.85rem",
+													marginTop: 4,
+												}}
+											/>
+										</div>
+									</PCS.ParsedTestcaseContent>
+								</PCS.ParsedTestcaseItem>
+							))}
+						</PCS.ParsedTestcases>
+						<PCS.AddSampleButton
+							type="button"
+							onClick={addTestCase}
+							style={{ marginTop: "0.75rem" }}
+						>
+							+ 테스트케이스 추가
+						</PCS.AddSampleButton>
+					</PCS.ParsedTestcasesSection>
+				) : (
+					<>
+						<div style={{ color: "#64748b", fontSize: "0.9rem", marginBottom: 8 }}>
+							테스트케이스가 없습니다. 추가해 주세요.
+						</div>
+						<PCS.AddSampleButton type="button" onClick={addTestCase}>
+							+ 테스트케이스 추가
+						</PCS.AddSampleButton>
+					</>
+				)}
+			</PCS.FormSection>
+
+			{/* 승인 버튼 */}
+			<div style={{ marginTop: "1rem" }}>
+				<S.ApproveButton type="button" onClick={onApprove}>
+					{isApproved ? "승인 취소" : "승인 ✓"}
+				</S.ApproveButton>
+			</div>
+				</PCS.FormGrid>
+			</div>
+
+			{/* 미리보기 패널 (접었다 펼 수 있음) */}
+			<S.PreviewDrawer $expanded={previewExpanded}>
+				<S.PreviewDrawerInner>
+					<S.PreviewDrawerHeader>
+						<span style={{ fontWeight: 600, fontSize: "0.9rem" }}>미리보기</span>
+						<S.PreviewDrawerClose
+							type="button"
+							onClick={() => setPreviewExpanded(false)}
+							title="미리보기 접기"
+						>
+							접기 ◀
+						</S.PreviewDrawerClose>
+					</S.PreviewDrawerHeader>
+					<PCS.PreviewHeader style={{ padding: "0.5rem 1rem" }}>
+						<PCS.PreviewModeToggle>
+							<PCS.PreviewModeButton
+								type="button"
+								$active={previewMode === "descriptionOnly"}
+								onClick={() => setPreviewMode("descriptionOnly")}
+							>
+								문제 설명만
+							</PCS.PreviewModeButton>
+							<PCS.PreviewModeButton
+								type="button"
+								$active={previewMode === "full"}
+								onClick={() => setPreviewMode("full")}
+							>
+								전체
+							</PCS.PreviewModeButton>
+						</PCS.PreviewModeToggle>
+					</PCS.PreviewHeader>
+					<PCS.PreviewContent
+						style={{ flex: 1, overflowY: "auto", padding: "0 1rem 1rem" }}
+					>
+						<ProblemPreview
+							{...getPreviewProps()}
+							descriptionOnly={previewMode === "descriptionOnly"}
+						/>
+					</PCS.PreviewContent>
+				</S.PreviewDrawerInner>
+			</S.PreviewDrawer>
+		</S.PreviewDrawerWrapper>
+	);
+}

--- a/src/pages/TutorPage/Problems/ProblemImport/hooks/useProblemImport.ts
+++ b/src/pages/TutorPage/Problems/ProblemImport/hooks/useProblemImport.ts
@@ -1,0 +1,154 @@
+import { useState, useCallback, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import APIService from "../../../../../services/APIService";
+import type { BulkParseItemResult, EditableProblem } from "../types";
+import { toProblemCreateRequest } from "../utils";
+
+export function useProblemImport() {
+	const navigate = useNavigate();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const [zipFile, setZipFile] = useState<File | null>(null);
+	const [parseResults, setParseResults] = useState<BulkParseItemResult[]>([]);
+	const [editableProblems, setEditableProblems] = useState<EditableProblem[]>([]);
+	const [selectedIndex, setSelectedIndex] = useState<number>(0);
+	const [approvedSet, setApprovedSet] = useState<Set<number>>(new Set());
+	const [isParsing, setIsParsing] = useState(false);
+	const [isUploading, setIsUploading] = useState(false);
+	const [parseError, setParseError] = useState<string | null>(null);
+	const [uploadResultModal, setUploadResultModal] = useState<{
+		success: boolean;
+		message: string;
+	} | null>(null);
+
+	const selectFile = useCallback(() => {
+		fileInputRef.current?.click();
+	}, []);
+
+	const handleFileChange = useCallback(
+		async (e: React.ChangeEvent<HTMLInputElement>) => {
+			const file = e.target.files?.[0];
+			if (!file) return;
+			if (!file.name.endsWith(".zip")) {
+				setParseError("ZIP 파일만 업로드 가능합니다.");
+				return;
+			}
+			setParseError(null);
+			setZipFile(file);
+			setIsParsing(true);
+			try {
+				const fd = new FormData();
+				fd.append("zipFile", file);
+				const results: BulkParseItemResult[] = await APIService.parseBulkZip(fd);
+				setParseResults(results);
+
+				const editables: EditableProblem[] = [];
+				results.forEach((r, i) => {
+					if (r.success && r.parseResult) {
+						editables.push(
+							toProblemCreateRequest(r.parseResult, i, r.filename),
+						);
+					}
+				});
+				setEditableProblems(editables);
+				setSelectedIndex(editables.length > 0 ? 0 : -1); // 0 = first in list
+				setApprovedSet(new Set());
+			} catch (err: unknown) {
+				setParseError(
+					err instanceof Error ? err.message : "ZIP 파싱에 실패했습니다.",
+				);
+			} finally {
+				setIsParsing(false);
+				e.target.value = "";
+			}
+		},
+		[],
+	);
+
+	const updateProblem = useCallback(
+		(listIndex: number, updates: Partial<EditableProblem>) => {
+			setEditableProblems((prev) =>
+				prev.map((p, i) => (i === listIndex ? { ...p, ...updates } : p)),
+			);
+		},
+		[],
+	);
+
+	const toggleApproved = useCallback((listIndex: number) => {
+		setApprovedSet((prev) => {
+			const next = new Set(prev);
+			if (next.has(listIndex)) next.delete(listIndex);
+			else next.add(listIndex);
+			return next;
+		});
+	}, []);
+
+	const approveAll = useCallback(() => {
+		setApprovedSet(new Set(editableProblems.map((_, i) => i)));
+	}, [editableProblems]);
+
+	const selectedProblem =
+		selectedIndex >= 0 && selectedIndex < editableProblems.length
+			? editableProblems[selectedIndex]
+			: undefined;
+
+	const uploadApproved = useCallback(async () => {
+		const approved = editableProblems.filter((_, i) => approvedSet.has(i));
+		if (approved.length === 0) {
+			setUploadResultModal({
+				success: false,
+				message: "승인된 문제가 없습니다. 체크박스로 승인할 문제를 선택하세요.",
+			});
+			return;
+		}
+
+		setIsUploading(true);
+		setUploadResultModal(null);
+		try {
+			const payload = approved.map(({ _index, _filename, ...rest }) => rest as any);
+			const res = await APIService.bulkCreateProblems(payload);
+			const count = res?.successCount ?? res?.createdIds?.length ?? approved.length;
+			setUploadResultModal({
+				success: true,
+				message: `${count}개 문제가 성공적으로 등록되었습니다.`,
+			});
+		} catch (err: unknown) {
+			const msg =
+				err instanceof Error ? err.message : "업로드에 실패했습니다.";
+			setUploadResultModal({ success: false, message: msg });
+		} finally {
+			setIsUploading(false);
+		}
+	}, [editableProblems, approvedSet]);
+
+	const closeResultModal = useCallback(() => {
+		setUploadResultModal(null);
+	}, []);
+
+	const goBack = useCallback(() => {
+		navigate("/tutor/problems");
+	}, [navigate]);
+
+	return {
+		fileInputRef,
+		zipFile,
+		parseResults,
+		editableProblems,
+		selectedIndex,
+		setSelectedIndex,
+		selectedProblem,
+		approvedSet,
+		toggleApproved,
+		approveAll,
+		updateProblem,
+		isParsing,
+		isUploading,
+		parseError,
+		uploadResultModal,
+		selectFile,
+		handleFileChange,
+		uploadApproved,
+		closeResultModal,
+		goBack,
+	};
+}

--- a/src/pages/TutorPage/Problems/ProblemImport/index.tsx
+++ b/src/pages/TutorPage/Problems/ProblemImport/index.tsx
@@ -1,0 +1,9 @@
+import { useProblemImport } from "./hooks/useProblemImport";
+import ProblemImportView from "./components/ProblemImportView";
+
+const ProblemImport = () => {
+	const hook = useProblemImport();
+	return <ProblemImportView {...hook} />;
+};
+
+export default ProblemImport;

--- a/src/pages/TutorPage/Problems/ProblemImport/styles.ts
+++ b/src/pages/TutorPage/Problems/ProblemImport/styles.ts
@@ -1,0 +1,370 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+	padding: 0;
+`;
+
+export const PageHeader = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 1.5rem;
+`;
+
+export const PageTitle = styled.h1`
+	font-size: 1.5rem;
+	font-weight: 700;
+	color: #1e293b;
+	margin: 0;
+`;
+
+export const BackButton = styled.button`
+	padding: 0.75rem 1.25rem;
+	background: #f1f5f9;
+	border: 2px solid #e2e8f0;
+	color: #475569;
+	border-radius: 8px;
+	font-weight: 500;
+	cursor: pointer;
+	font-size: 0.95rem;
+	transition: all 0.2s ease;
+
+	&:hover {
+		background: #e2e8f0;
+	}
+`;
+
+export const Layout = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 320px;
+	gap: 1.5rem;
+	min-height: 500px;
+
+	@media (max-width: 900px) {
+		grid-template-columns: 1fr;
+	}
+`;
+
+export const MainPanel = styled.div`
+	background: white;
+	border-radius: 12px;
+	padding: 1.5rem;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+	border: 1px solid #e5e7eb;
+`;
+
+export const Sidebar = styled.div`
+	background: white;
+	border-radius: 12px;
+	padding: 1rem;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+	border: 1px solid #e5e7eb;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+`;
+
+export const FileSelectButton = styled.button`
+	width: 100%;
+	padding: 1rem 1.5rem;
+	background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+	color: white;
+	border: none;
+	border-radius: 8px;
+	font-weight: 600;
+	cursor: pointer;
+	font-size: 0.95rem;
+	transition: opacity 0.2s;
+
+	&:hover {
+		opacity: 0.9;
+	}
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+`;
+
+export const ProblemList = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	max-height: 400px;
+	overflow-y: auto;
+`;
+
+export const ProblemListItem = styled.div<{ $selected?: boolean }>`
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.75rem 1rem;
+	border-radius: 8px;
+	cursor: pointer;
+	background: ${(p) => (p.$selected ? "#eef2ff" : "#f8fafc")};
+	border: 1px solid ${(p) => (p.$selected ? "#667eea" : "#e2e8f0")};
+
+	&:hover {
+		background: #f1f5f9;
+	}
+`;
+
+export const ListCheckbox = styled.input`
+	width: 18px;
+	height: 18px;
+	cursor: pointer;
+`;
+
+export const ListTitle = styled.span`
+	font-weight: 500;
+	color: #1e293b;
+	font-size: 0.9rem;
+`;
+
+export const ApproveAllButton = styled.button`
+	padding: 0.5rem 1rem;
+	background: #f1f5f9;
+	border: 1px solid #e2e8f0;
+	border-radius: 6px;
+	font-size: 0.85rem;
+	cursor: pointer;
+	transition: all 0.2s;
+
+	&:hover {
+		background: #e2e8f0;
+	}
+`;
+
+export const UploadButton = styled.button`
+	width: 100%;
+	padding: 0.75rem 1.25rem;
+	background: #059669;
+	color: white;
+	border: none;
+	border-radius: 8px;
+	font-weight: 600;
+	cursor: pointer;
+	font-size: 0.95rem;
+	transition: opacity 0.2s;
+	margin-top: 0.5rem;
+
+	&:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+`;
+
+export const FormSection = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	margin-bottom: 1rem;
+`;
+
+export const Label = styled.label`
+	font-weight: 500;
+	color: #334155;
+	font-size: 0.9rem;
+`;
+
+export const Input = styled.input`
+	padding: 0.6rem 0.9rem;
+	border: 1px solid #e2e8f0;
+	border-radius: 6px;
+	font-size: 0.95rem;
+
+	&:focus {
+		outline: none;
+		border-color: #667eea;
+	}
+`;
+
+export const Textarea = styled.textarea`
+	padding: 0.75rem 1rem;
+	border: 1px solid #e2e8f0;
+	border-radius: 6px;
+	font-family: inherit;
+	font-size: 0.9rem;
+	line-height: 1.5;
+	resize: vertical;
+	min-height: 120px;
+
+	&:focus {
+		outline: none;
+		border-color: #667eea;
+	}
+`;
+
+export const Select = styled.select`
+	padding: 0.6rem 0.9rem;
+	border: 1px solid #e2e8f0;
+	border-radius: 6px;
+	font-size: 0.95rem;
+	background: white;
+
+	&:focus {
+		outline: none;
+		border-color: #667eea;
+	}
+`;
+
+export const FormRow = styled.div`
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 1rem;
+`;
+
+export const ApproveButton = styled.button`
+	padding: 0.6rem 1.2rem;
+	background: #667eea;
+	color: white;
+	border: none;
+	border-radius: 6px;
+	font-weight: 500;
+	cursor: pointer;
+	font-size: 0.9rem;
+	margin-right: 0.5rem;
+
+	&:hover {
+		opacity: 0.9;
+	}
+`;
+
+export const ErrorMessage = styled.div`
+	background: #fee2e2;
+	color: #dc2626;
+	padding: 1rem 1.5rem;
+	border-radius: 8px;
+	margin-bottom: 1rem;
+	border: 1px solid #fecaca;
+`;
+
+export const EmptyState = styled.div`
+	text-align: center;
+	padding: 2rem;
+	color: #64748b;
+	font-size: 0.95rem;
+`;
+
+export const ModalOverlay = styled.div`
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.4);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 10000;
+`;
+
+export const ModalContent = styled.div`
+	background: white;
+	border-radius: 12px;
+	padding: 1.5rem 2rem;
+	min-width: 320px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+`;
+
+export const ModalTitle = styled.h3<{ $success?: boolean }>`
+	margin: 0 0 1rem 0;
+	font-size: 1.1rem;
+	color: ${(p) => (p.$success ? "#059669" : "#dc2626")};
+`;
+
+export const ModalMessage = styled.p`
+	margin: 0 0 1.25rem 0;
+	color: #475569;
+	font-size: 0.95rem;
+	line-height: 1.5;
+`;
+
+export const ModalButton = styled.button`
+	padding: 0.6rem 1.25rem;
+	background: #667eea;
+	color: white;
+	border: none;
+	border-radius: 6px;
+	font-weight: 500;
+	cursor: pointer;
+	font-size: 0.9rem;
+
+	&:hover {
+		opacity: 0.9;
+	}
+`;
+
+/** 미리보기 패널 컨테이너 (접었다 펼 수 있음) */
+export const PreviewDrawerWrapper = styled.div`
+	position: relative;
+	display: flex;
+	min-height: 0;
+	width: 100%;
+`;
+
+/** 문제 설명 옆 펼치기 버튼 */
+export const PreviewDrawerToggle = styled.button`
+	padding: 0.4rem 0.8rem;
+	background: #667eea;
+	color: white;
+	border: none;
+	border-radius: 6px;
+	cursor: pointer;
+	font-size: 0.85rem;
+	font-weight: 500;
+	transition: background 0.2s;
+
+	&:hover {
+		background: #5568d3;
+	}
+`;
+
+export const PreviewDrawer = styled.div<{ $expanded: boolean }>`
+	width: ${(p) => (p.$expanded ? "420px" : "0")};
+	min-width: 0;
+	overflow: hidden;
+	transition: width 0.25s ease;
+	border-left: ${(p) => (p.$expanded ? "1px solid #e2e8f0" : "none")};
+	margin-left: ${(p) => (p.$expanded ? "1rem" : "0")};
+	display: flex;
+	flex-direction: column;
+	background: #f8fafc;
+	border-radius: 0 8px 8px 0;
+`;
+
+export const PreviewDrawerInner = styled.div`
+	width: 420px;
+	min-width: 420px;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+`;
+
+export const PreviewDrawerHeader = styled.div`
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.75rem 1rem;
+	background: #f1f5f9;
+	border-bottom: 1px solid #e2e8f0;
+	flex-shrink: 0;
+`;
+
+export const PreviewDrawerClose = styled.button`
+	padding: 0.35rem 0.6rem;
+	background: #e2e8f0;
+	border: none;
+	border-radius: 6px;
+	cursor: pointer;
+	font-size: 0.85rem;
+	color: #475569;
+	transition: all 0.2s;
+
+	&:hover {
+		background: #cbd5e1;
+		color: #334155;
+	}
+`;

--- a/src/pages/TutorPage/Problems/ProblemImport/types.ts
+++ b/src/pages/TutorPage/Problems/ProblemImport/types.ts
@@ -1,0 +1,27 @@
+import type { ProblemCreateRequest, TestCaseDto } from "../ProblemCreate/types";
+
+/** 백엔드 BulkParseItemResult */
+export interface BulkParseItemResult {
+	filename: string;
+	success: boolean;
+	parseResult?: ProblemFileParseResult;
+	validationErrors?: string[];
+}
+
+/** 백엔드 ProblemFileParseResult */
+export interface ProblemFileParseResult {
+	title?: string;
+	description?: string;
+	inputFormat?: string;
+	outputFormat?: string;
+	sampleInputs?: { input?: string; output?: string }[];
+	timeLimit?: number;
+	memoryLimit?: number;
+	testcases?: { name?: string; input?: string; output?: string; type?: string }[];
+}
+
+/** 편집 중인 문제 (parseResult → ProblemCreateRequest 변환용) */
+export interface EditableProblem extends ProblemCreateRequest {
+	_index: number;
+	_filename: string;
+}

--- a/src/pages/TutorPage/Problems/ProblemImport/utils.ts
+++ b/src/pages/TutorPage/Problems/ProblemImport/utils.ts
@@ -1,0 +1,38 @@
+import type {
+	ProblemFileParseResult,
+	EditableProblem,
+} from "./types";
+import type { ProblemCreateRequest, TestCaseDto } from "../ProblemCreate/types";
+
+export function toProblemCreateRequest(
+	pr: ProblemFileParseResult,
+	index: number,
+	filename: string,
+): EditableProblem {
+	const testcases: TestCaseDto[] = (pr.testcases ?? []).map((tc) => ({
+		name: tc.name ?? "1",
+		input: tc.input ?? "",
+		output: tc.output ?? "",
+		type: (tc.type === "sample" ? "sample" : "secret") as "sample" | "secret",
+	}));
+
+	const sampleInputs = pr.sampleInputs ?? [];
+	const sampleInputsJson = JSON.stringify(
+		sampleInputs.map((s) => ({ input: s.input ?? "", output: s.output ?? "" })),
+	);
+
+	return {
+		_index: index,
+		_filename: filename,
+		title: pr.title ?? "",
+		description: pr.description ?? "",
+		inputFormat: pr.inputFormat ?? "",
+		outputFormat: pr.outputFormat ?? "",
+		tags: "[]",
+		difficulty: "1",
+		timeLimit: String(pr.timeLimit ?? 1),
+		memoryLimit: String(pr.memoryLimit ?? 256),
+		sampleInputs: sampleInputsJson,
+		testcases,
+	};
+}

--- a/src/pages/TutorPage/Problems/ProblemManagement/components/ProblemManagementView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemManagement/components/ProblemManagementView.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
-import { FaFileExport } from "react-icons/fa";
+import { FaFileExport, FaFileImport } from "react-icons/fa";
 import TutorLayout from "../../../../../layouts/TutorLayout";
 import ReactMarkdown from "react-markdown";
 import rehypeRaw from "rehype-raw";
@@ -103,6 +103,13 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 						</S.TitleStats>
 					</S.TitleLeft>
 					<S.TitleRight>
+						<S.ExportButton
+							style={{ background: "rgba(255,255,255,0.85)" }}
+							onClick={() => d.navigate("/tutor/problems/import")}
+						>
+							<FaFileImport style={{ marginRight: "0.5rem", flexShrink: 0 }} />
+							문제 가져오기
+						</S.ExportButton>
 						<S.ExportButton
 							onClick={() => {
 								if (d.selectedProblemIds.length > 0) {

--- a/src/pages/TutorPage/Problems/ProblemManagement/hooks/useProblemManagement.ts
+++ b/src/pages/TutorPage/Problems/ProblemManagement/hooks/useProblemManagement.ts
@@ -421,7 +421,11 @@ export function useProblemManagement() {
 			try {
 				setIsExporting(true);
 				const blob = await APIService.exportProblem(problem.id);
-				triggerDownload(blob, `problem-${problem.id}.zip`);
+				const safeName = (problem.title || `problem-${problem.id}`)
+					.replace(/[/\\:*?"<>|]/g, "_")
+					.replace(/\s+/g, "_")
+					.trim() || `problem-${problem.id}`;
+				triggerDownload(blob, `${safeName}.zip`);
 				setAlertMessage(`문제 "${problem.title}" 내보내기가 완료되었습니다.`);
 				setAlertType("success");
 				setTimeout(() => setAlertMessage(null), 3000);

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -570,6 +570,44 @@ class APIService {
 		return response.blob();
 	}
 
+	/**
+	 * Bulk Parse (HandongJudge 포맷 ZIP 파싱)
+	 */
+	async parseBulkZip(formData: FormData): Promise<any> {
+		const url = `${this.baseURL}/problems/bulk/parse`;
+		let accessToken = tokenManager.getAccessToken();
+		const doFetch = () => {
+			const config: RequestInit = {
+				method: "POST",
+				credentials: "include",
+				headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+				body: formData,
+			};
+			return fetch(url, config);
+		};
+		let response = await doFetch();
+		if (response.status === 401) {
+			await tokenManager.refreshToken();
+			accessToken = tokenManager.getAccessToken();
+			if (accessToken) response = await doFetch();
+		}
+		if (!response.ok) {
+			const err = await response.json().catch(() => ({}));
+			throw new Error(err.message || `Bulk Parse 실패: ${response.status}`);
+		}
+		return response.json();
+	}
+
+	/**
+	 * Bulk Create (승인된 문제 목록 생성)
+	 */
+	async bulkCreateProblems(problems: any[]): Promise<any> {
+		return await this.request("/problems/bulk", {
+			method: "POST",
+			body: JSON.stringify({ problems }),
+		});
+	}
+
 	async copySection(
 		sectionId: number | string,
 		sectionNumber: string,


### PR DESCRIPTION
[문제 가져오기]
- ZIP 파일 선택 → 파싱 → 편집 → 승인 → 일괄 업로드 플로우
- EditForm: ProblemCreate와 동일한 구조 (제목, 난이도, 태그, 입출력 형식, 예제, 테스트케이스)
- 테스트케이스 섹션: 이름/타입/입출력 편집, 추가·삭제 지원
- 미리보기 패널: 문제 설명만/전체 토글, 접었다 펼 수 있는 사이드 패널
- 업로드 완료 시 리다이렉트 제거

[1문제 내보내기]
- 다운로드 파일명: problem-{id}.zip → {문제제목}.zip
- ZIP 내부 폴더명: 문제 제목 기준 (BE)

## #️⃣연관된 이슈

> #133 
