### PR TITLE
feat/issue-140/src/togglebutton_in_assignmentandnotice

### DIFF
--- a/src/components/UI/ActiveToggle/index.tsx
+++ b/src/components/UI/ActiveToggle/index.tsx
@@ -1,0 +1,57 @@
+import type React from "react";
+import * as S from "./styles";
+
+export interface ActiveToggleProps {
+	/** 현재 활성 여부 (true = ON/초록, false = OFF/빨강) */
+	active: boolean;
+	/** 토글 클릭 시 호출. 새 값은 !active 로 전달하지 않고, 부모에서 기존 API 호출 시 사용 */
+	onToggle: () => void;
+	/** 토글 안에 활성/비활성 텍스트 표시 여부 */
+	showLabel?: boolean;
+	/** 비활성화 (로딩 등) */
+	disabled?: boolean;
+	/** 접근성용 title */
+	title?: string;
+	/** 추가 className */
+	className?: string;
+}
+
+/**
+ * 활성/비활성 상태용 토글.
+ * - active=true: 초록 배경, 노브 오른쪽, 활성 텍스트(선택)
+ * - active=false: 빨강 배경, 노브 왼쪽, 비활성 텍스트(선택)
+ */
+const ActiveToggle: React.FC<ActiveToggleProps> = ({
+	active,
+	onToggle,
+	showLabel = true,
+	disabled = false,
+	title,
+	className,
+}) => {
+	const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+		e.stopPropagation();
+		if (!disabled) onToggle();
+	};
+
+	const label = active ? "활성" : "비활성";
+	const a11yTitle = title ?? (active ? "비활성화하려면 클릭" : "활성화하려면 클릭");
+
+	return (
+		<S.ToggleTrack
+			type="button"
+			$active={active}
+			onClick={handleClick}
+			disabled={disabled}
+			title={a11yTitle}
+			aria-checked={active}
+			aria-label={a11yTitle}
+			className={className}
+		>
+			{showLabel && <S.ToggleLabel>{label}</S.ToggleLabel>}
+			<S.ToggleKnob $active={active} />
+		</S.ToggleTrack>
+	);
+};
+
+export default ActiveToggle;

--- a/src/components/UI/ActiveToggle/styles.ts
+++ b/src/components/UI/ActiveToggle/styles.ts
@@ -1,0 +1,54 @@
+import styled from "styled-components";
+
+export const ToggleTrack = styled.button<{ $active: boolean }>`
+	display: inline-flex;
+	align-items: center;
+	justify-content: space-between;
+	min-width: 72px;
+	height: 32px;
+	padding: 0 6px;
+	margin-right: 6px;
+	border: 1px solid rgba(0, 0, 0, 0.15);
+	border-radius: 6px;
+	background-color: ${(p) => (p.$active ? "#22c55e" : "#ef4444")};
+	color: white;
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: background-color 0.2s;
+	/* 트랙이 살짝 들어간 느낌 → 노브가 올라와 보이게 */
+	box-shadow:
+		inset 0 2px 4px rgba(0, 0, 0, 0.15),
+		0 1px 2px rgba(0, 0, 0, 0.08);
+
+	&:focus {
+		outline: 2px solid ${(p) => (p.$active ? "#22c55e" : "#ef4444")};
+		outline-offset: 2px;
+	}
+	&:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+`;
+
+export const ToggleKnob = styled.span<{ $active: boolean }>`
+	width: 24px;
+	height: 24px;
+	border-radius: 4px;
+	background: linear-gradient(180deg, #ffffff 0%, #f1f5f9 100%);
+	border: 1px solid rgba(255, 255, 255, 0.9);
+	flex-shrink: 0;
+	order: ${(p) => (p.$active ? 2 : 0)};
+	transition: box-shadow 0.2s;
+	/* 입체감: 위쪽 하이라이트 + 아래쪽 그림자 */
+	box-shadow:
+		0 2px 4px rgba(0, 0, 0, 0.25),
+		0 1px 0 rgba(255, 255, 255, 0.4) inset;
+`;
+
+export const ToggleLabel = styled.span`
+	order: 1;
+	user-select: none;
+	white-space: nowrap;
+	padding: 0 4px;
+`;

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentManagementHeader.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentManagementHeader.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import * as S from "./styles";
+import ActiveToggle from "../../../../components/UI/ActiveToggle";
 
 interface AssignmentManagementHeaderProps {
 	sectionId: string | undefined;
@@ -13,6 +14,9 @@ interface AssignmentManagementHeaderProps {
 	onBulkProblemCreate: () => void;
 	/** 조교(TUTOR)인 수업이면 과제 추가/수정 등 제한 */
 	isTutorOnly?: boolean;
+	/** 분반 페이지일 때 전체 활성/비활성 토글 (sectionId 있을 때만 사용) */
+	sectionAllActive?: boolean;
+	onBulkToggleActive?: (targetActive: boolean) => void;
 }
 
 const AssignmentManagementHeader: React.FC<AssignmentManagementHeaderProps> = ({
@@ -26,6 +30,8 @@ const AssignmentManagementHeader: React.FC<AssignmentManagementHeaderProps> = ({
 	onStandaloneProblemCreate,
 	onBulkProblemCreate,
 	isTutorOnly,
+	sectionAllActive = false,
+	onBulkToggleActive,
 }) => {
 	/* 2번 사진 원본: 헤더에 제목 + 오른쪽 "과제 추가하기" 버튼만, 뱃지 없음 */
 	if (sectionId) {
@@ -35,13 +41,23 @@ const AssignmentManagementHeader: React.FC<AssignmentManagementHeaderProps> = ({
 					<S.HeaderLeft>
 						<S.PageTitle>과제 관리</S.PageTitle>
 					</S.HeaderLeft>
-					{!isTutorOnly && (
-						<S.HeaderActions>
+					<S.HeaderActions>
+						{!isTutorOnly && onBulkToggleActive && (
+							<S.BulkToggleWrap>
+								<span>전체 활성화</span>
+								<ActiveToggle
+									active={sectionAllActive}
+									onToggle={() => onBulkToggleActive(!sectionAllActive)}
+									showLabel={true}
+								/>
+							</S.BulkToggleWrap>
+						)}
+						{!isTutorOnly && (
 							<S.BtnPrimary type="button" onClick={onAddAssignment}>
 								과제 추가하기
 							</S.BtnPrimary>
-						</S.HeaderActions>
-					)}
+						)}
+					</S.HeaderActions>
 				</S.PageHeader>
 				<S.FiltersSection>
 					<S.SearchBox>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx
@@ -1,6 +1,7 @@
 import type React from "react";
 import { removeCopyLabel } from "../../../../../utils/problemUtils";
 import { getDifficultyColor } from "../../../../../utils/assignmentUtils";
+import ActiveToggle from "../../../../../components/UI/ActiveToggle";
 
 interface Problem {
 	id: number;
@@ -157,33 +158,32 @@ const AssignmentListView: React.FC<AssignmentListViewProps> = ({
 									</button>
 								</>
 							)}
+							{!isTutorOnly && (
+								<ActiveToggle
+									active={assignment.active !== false}
+									onToggle={() =>
+										onToggleActive(
+											assignment.sectionId,
+											assignment.id,
+											assignment.active,
+										)
+									}
+									showLabel={true}
+								/>
+							)}
 							<div className="tutor-more-menu">
 								<button
 									className="tutor-btn-list-action tutor-btn-more"
 									title="더보기"
 									onClick={(e) => {
 										e.stopPropagation();
-										onToggleMoreMenu(assignment.id);
+										onToggleMoreMenu(openMoreMenu === assignment.id ? null : assignment.id);
 									}}
 								>
 									⋯
 								</button>
 								{openMoreMenu === assignment.id && (
 									<div className="tutor-more-dropdown">
-										<button
-											className="tutor-btn-text-small"
-											onClick={(e) => {
-												e.stopPropagation();
-												onToggleActive(
-													assignment.sectionId,
-													assignment.id,
-													assignment.active,
-												);
-												onToggleMoreMenu(null);
-											}}
-										>
-											{assignment.active ? "비활성화" : "활성화"}
-										</button>
 										<button
 											className="tutor-btn-text-small tutor-delete"
 											onClick={(e) => {

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import AssignmentPagination from "../../../../../components/Navigation/Pagination/AssignmentPagination";
+import ActiveToggle from "../../../../../components/UI/ActiveToggle";
 
 interface Assignment {
 	id: number;
@@ -166,21 +167,19 @@ const AssignmentTableView: React.FC<AssignmentTableViewProps> = ({
 										)}
 										<div className="tutor-assignment-secondary-actions">
 											<div className="tutor-secondary-actions-layer">
-												<button
-													type="button"
-													className="tutor-btn-table-action tutor-btn-secondary-action"
-													onClick={(e) => {
-														e.stopPropagation();
-														onToggleActive(
-															assignment.sectionId,
-															assignment.id,
-															assignment.active,
-														);
-													}}
-													title={assignment.active ? "비활성화" : "활성화"}
-												>
-													{assignment.active ? "비활성화" : "활성화"}
-												</button>
+												{!isTutorOnly && (
+													<ActiveToggle
+														active={assignment.active !== false}
+														onToggle={() =>
+															onToggleActive(
+																assignment.sectionId,
+																assignment.id,
+																assignment.active,
+															)
+														}
+														showLabel={true}
+													/>
+												)}
 												<div className="tutor-more-menu">
 													<button
 														type="button"

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts
@@ -372,6 +372,30 @@ export function useAssignmentManagement() {
 		[refetchAssignments],
 	);
 
+	const handleBulkToggleActive = useCallback(
+		async (targetActive: boolean) => {
+			if (!sectionId) return;
+			const list = assignments;
+			for (const a of list) {
+				if (a.active === targetActive) continue;
+				try {
+					await APIService.toggleAssignmentActive(
+						a.sectionId,
+						a.id,
+						targetActive,
+					);
+				} catch (error) {
+					console.error("과제 활성/비활성 변경 실패:", error);
+					alert("일부 과제 활성/비활성 변경에 실패했습니다.");
+					await refetchAssignments();
+					return;
+				}
+			}
+			await refetchAssignments();
+		},
+		[sectionId, assignments, refetchAssignments],
+	);
+
 	const handleAddProblem = useCallback(
 		async (assignment: Assignment) => {
 			setSelectedAssignment(assignment);
@@ -956,6 +980,12 @@ export function useAssignmentManagement() {
 		(currentSection as { roleInSection?: string } | null)?.roleInSection ===
 		"TUTOR";
 
+	const sectionAssignments = sectionId ? assignments : [];
+	// 전체 활성화: 모든 항목이 비활성이면 OFF, 하나라도 활성이 있으면 ON
+	const sectionAllActive =
+		sectionAssignments.length > 0 &&
+		sectionAssignments.some((a: Assignment) => a.active !== false);
+
 	return {
 		loading,
 		sectionId,
@@ -1024,6 +1054,8 @@ export function useAssignmentManagement() {
 		handleInputChange,
 		handleDelete,
 		handleToggleActive,
+		handleBulkToggleActive,
+		sectionAllActive,
 		handleAddProblem,
 		isAddingProblems,
 		isSubmittingAdd,

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/index.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/index.tsx
@@ -78,6 +78,8 @@ const AssignmentManagement: React.FC = () => {
 					onStandaloneProblemCreate={d.handleStandaloneProblemCreate}
 					onBulkProblemCreate={d.handleBulkProblemCreate}
 					isTutorOnly={d.isTutorOnly}
+					sectionAllActive={d.sectionAllActive}
+					onBulkToggleActive={d.handleBulkToggleActive}
 				/>
 
 				{d.sectionId ? (

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/styles.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/styles.ts
@@ -61,6 +61,14 @@ export const HeaderActions = styled.div`
   flex-wrap: wrap;
 `;
 
+export const BulkToggleWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: white;
+  font-size: 0.875rem;
+`;
+
 /** 필터/검색 섹션 */
 export const FiltersSection = styled.div`
   display: flex;

--- a/src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeHeader.tsx
+++ b/src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeHeader.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 import * as S from "../styles";
 import type { Section } from "../types";
+import ActiveToggle from "../../../../../components/UI/ActiveToggle";
 
 interface NoticeHeaderProps {
 	isSectionPage: boolean;
@@ -12,6 +13,8 @@ interface NoticeHeaderProps {
 	uniqueSections: { id: number; name: string }[];
 	onCreateNotice: () => void;
 	onCopyEnrollmentLink: () => void;
+	sectionAllActive?: boolean;
+	onBulkToggleActive?: (targetActive: boolean) => void;
 }
 
 const NoticeHeader: FC<NoticeHeaderProps> = ({
@@ -24,6 +27,8 @@ const NoticeHeader: FC<NoticeHeaderProps> = ({
 	uniqueSections,
 	onCreateNotice,
 	onCopyEnrollmentLink,
+	sectionAllActive = false,
+	onBulkToggleActive,
 }) => {
 	if (isSectionPage && currentSection) {
 		return (
@@ -32,6 +37,16 @@ const NoticeHeader: FC<NoticeHeaderProps> = ({
 					<S.PageTitle>{currentSection.courseTitle}</S.PageTitle>
 				</S.HeaderLeft>
 				<S.HeaderRight>
+					{onBulkToggleActive && (
+						<S.BulkToggleWrap>
+							<span>전체 활성화</span>
+							<ActiveToggle
+								active={sectionAllActive}
+								onToggle={() => onBulkToggleActive(!sectionAllActive)}
+								showLabel={true}
+							/>
+						</S.BulkToggleWrap>
+					)}
 					{currentSection.enrollmentCode && (
 						<S.LinkCopyButton
 							onClick={onCopyEnrollmentLink}

--- a/src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeTable.tsx
+++ b/src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeTable.tsx
@@ -2,6 +2,7 @@ import type { FC } from "react";
 import * as S from "../styles";
 import { getSectionNameWithoutSection } from "../utils/sectionUtils";
 import type { Notice } from "../types";
+import ActiveToggle from "../../../../../components/UI/ActiveToggle";
 
 interface NoticeTableProps {
 	notices: Notice[];
@@ -95,16 +96,13 @@ const NoticeTable: FC<NoticeTableProps> = ({
 									</S.PrimaryActions>
 									<S.SecondaryActions>
 										<S.SecondaryActionsLayer>
-											<S.TableButton
-												variant="secondary"
-												onClick={(e) => {
-													e.stopPropagation();
-													onToggleActive(notice.id, notice.active);
-												}}
-												title={notice.active ? "비활성화" : "활성화"}
-											>
-												{notice.active ? "비활성화" : "활성화"}
-											</S.TableButton>
+											<ActiveToggle
+												active={notice.active}
+												onToggle={() =>
+													onToggleActive(notice.id, notice.active)
+												}
+												showLabel={true}
+											/>
 											<S.MoreMenu>
 												<S.TableButton
 													variant="secondary"

--- a/src/pages/TutorPage/Notices/NoticeManagementPage/hooks/useNoticeManagement.ts
+++ b/src/pages/TutorPage/Notices/NoticeManagementPage/hooks/useNoticeManagement.ts
@@ -108,6 +108,25 @@ export function useNoticeManagement() {
 		[fetchNotices],
 	);
 
+	const handleBulkToggleActive = useCallback(
+		async (targetActive: boolean) => {
+			if (!sectionId) return;
+			for (const notice of notices) {
+				if (notice.active === targetActive) continue;
+				try {
+					await APIService.toggleNoticeActive(notice.id, targetActive);
+				} catch (error) {
+					console.error("공지사항 활성/비활성 변경 실패:", error);
+					alert("일부 공지사항 활성/비활성 변경에 실패했습니다.");
+					await fetchNotices();
+					return;
+				}
+			}
+			await fetchNotices();
+		},
+		[sectionId, notices, fetchNotices],
+	);
+
 	const handleCopyEnrollmentLink = useCallback(() => {
 		if (currentSection?.enrollmentCode) {
 			const enrollmentLink = `${window.location.origin}/enroll/${currentSection.enrollmentCode}`;
@@ -133,6 +152,11 @@ export function useNoticeManagement() {
 
 	const uniqueSections = getUniqueSections(notices);
 
+	const sectionNotices = sectionId ? notices : [];
+	// 전체 활성화: 모든 항목이 비활성이면 OFF, 하나라도 활성이 있으면 ON
+	const sectionAllActive =
+		sectionNotices.length > 0 && sectionNotices.some((n) => n.active);
+
 	return {
 		sectionId,
 		notices,
@@ -151,6 +175,8 @@ export function useNoticeManagement() {
 		handleEditNotice,
 		handleDeleteNotice,
 		handleToggleActive,
+		handleBulkToggleActive,
+		sectionAllActive,
 		handleCopyEnrollmentLink,
 	};
 }

--- a/src/pages/TutorPage/Notices/NoticeManagementPage/index.tsx
+++ b/src/pages/TutorPage/Notices/NoticeManagementPage/index.tsx
@@ -23,6 +23,8 @@ const NoticeManagementPage: FC = () => {
 		handleEditNotice,
 		handleDeleteNotice,
 		handleToggleActive,
+		handleBulkToggleActive,
+		sectionAllActive,
 		handleCopyEnrollmentLink,
 	} = useNoticeManagement();
 
@@ -52,6 +54,8 @@ const NoticeManagementPage: FC = () => {
 					uniqueSections={uniqueSections}
 					onCreateNotice={handleCreateNotice}
 					onCopyEnrollmentLink={handleCopyEnrollmentLink}
+					sectionAllActive={sectionAllActive}
+					onBulkToggleActive={handleBulkToggleActive}
 				/>
 				<NoticeTable
 					notices={filteredNotices}

--- a/src/pages/TutorPage/Notices/NoticeManagementPage/styles.ts
+++ b/src/pages/TutorPage/Notices/NoticeManagementPage/styles.ts
@@ -61,6 +61,14 @@ export const HeaderRight = styled.div`
   flex-wrap: wrap;
 `;
 
+export const BulkToggleWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: white;
+  font-size: 0.875rem;
+`;
+
 export const PageTitle = styled.h1`
   font-size: 1.875rem;
   font-weight: 700;
@@ -329,7 +337,7 @@ export const NewBadge = styled.span`
 
 export const ActionsInline = styled.div`
   display: flex;
-  gap: 0.5rem;
+  gap: 0.75rem;
   align-items: center;
   justify-content: flex-end;
   flex-wrap: nowrap;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #140 

## 📝작업 내용
# 과제/공지 활성·비활성 토글 UI 변경

## 개요

과제 관리·공지사항 관리 화면에서 기존 "활성화"/"비활성화" **버튼**을 **토글 스위치**로 교체하고, 분반(section) 페이지에 **전체 활성화/비활성화** 토글을 추가했다. 백엔드 API 변경 없이 프론트엔드만 수정했다.

---

## 1. 신규 컴포넌트: ActiveToggle

### 1.1 파일

| 경로 | 설명 |
|------|------|
| `src/components/UI/ActiveToggle/index.tsx` | 토글 컴포넌트 (Props, 클릭 핸들러, 라벨 "활성"/"비활성") |
| `src/components/UI/ActiveToggle/styles.ts` | 스타일 (트랙, 노브, 라벨) |

### 1.2 동작

- **Props**
  - `active: boolean` — 현재 활성 여부 (true: 초록/활성, false: 빨강/비활성)
  - `onToggle: () => void` — 클릭 시 호출 (부모에서 기존 API 호출)
  - `showLabel?: boolean` — "활성"/"비활성" 텍스트 표시 여부 (기본 true)
  - `disabled?`, `title?`, `className?`
- **표시**
  - 활성: 초록 배경(`#22c55e`), 노브 오른쪽, "활성" 텍스트
  - 비활성: 빨강 배경(`#ef4444`), 노브 왼쪽, "비활성" 텍스트
- **스타일**
  - 트랙: 박스형(`border-radius: 6px`), `min-width: 72px`, `height: 32px`, inset 그림자로 들어간 느낌
  - 노브: 24×24px, `border-radius: 4px`, 그라데이션 + 그림자로 입체감
  - 토글 오른쪽 여백 `margin-right: 6px` (옆 ⋯ 버튼과 간격)

---

## 2. 과제 관리 (Assignment Management)

### 2.1 항목별 토글 적용

#### `src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx`

- **수정 내용**
  - `ActiveToggle` import 추가.
  - 각 행의 "활성화"/"비활성화" **버튼** 제거 후, 같은 위치에 **ActiveToggle** 렌더링.
  - `isTutorOnly`일 때는 토글 미표시 (기존과 동일).
- **호출**
  - `active={assignment.active !== false}`
  - `onToggle={() => onToggleActive(assignment.sectionId, assignment.id, assignment.active)}`
  - 기존 `onToggleActive`(과제별 활성/비활성 API) 그대로 사용.

#### `src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx`

- **수정 내용**
  - `ActiveToggle` import 추가.
  - 더보기(⋯) 드롭다운 안에 있던 "활성화"/"비활성화" **버튼** 제거.
  - 행에 **ActiveToggle**을 더보기 버튼 왼쪽에 노출 (리스트에서도 상태 한눈에 보이도록).
  - 더보기 클릭 시 `onToggleMoreMenu(openMoreMenu === assignment.id ? null : assignment.id)` 로 열기/닫기 토글.
  - 드롭다운에는 "삭제"만 유지.

### 2.2 전체 활성화 토글 (헤더)

#### `src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentManagementHeader.tsx`

- **수정 내용**
  - `ActiveToggle` import.
  - Props 추가: `sectionAllActive?: boolean`, `onBulkToggleActive?: (targetActive: boolean) => void`.
  - **분반 페이지**(`sectionId` 있을 때)일 때만, 헤더 오른쪽에 다음 블록 추가:
    - "전체 활성화" 텍스트 + **ActiveToggle**
    - `active={sectionAllActive}`, `onToggle={() => onBulkToggleActive(!sectionAllActive)}`
  - 과제 추가하기 버튼은 그대로 유지.

#### `src/pages/TutorPage/Assignments/AssignmentManagement/styles.ts`

- **수정 내용**
  - `BulkToggleWrap` 스타일 추가: "전체 활성화" 라벨 + 토글을 감싸는 flex 컨테이너, 흰색 텍스트.

#### `src/pages/TutorPage/Assignments/AssignmentManagement/index.tsx`

- **수정 내용**
  - `AssignmentManagementHeader`에 `sectionAllActive={d.sectionAllActive}`, `onBulkToggleActive={d.handleBulkToggleActive}` 전달.

#### `src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts`

- **수정 내용**
  - **handleBulkToggleActive** 추가:
    - `sectionId` 없으면 return.
    - 현재 분반의 `assignments` 순회하며 `a.active !== targetActive` 인 항목만 `APIService.toggleAssignmentActive(a.sectionId, a.id, targetActive)` 호출.
    - 한 건이라도 실패 시 알림 후 `refetchAssignments()` 하고 종료.
    - 모두 성공 시 마지막에 `refetchAssignments()`.
  - **sectionAllActive** 계산 변경:
    - `sectionAssignments = sectionId ? assignments : []`
    - `sectionAllActive = sectionAssignments.length > 0 && sectionAssignments.some(a => a.active !== false)`
    - 즉, **모든 항목이 비활성일 때만 false(OFF)**, **하나라도 활성이 있으면 true(ON)**.
  - return 객체에 `handleBulkToggleActive`, `sectionAllActive` 추가.

---

## 3. 공지사항 관리 (Notice Management)

### 3.1 항목별 토글 적용

#### `src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeTable.tsx`

- **수정 내용**
  - `ActiveToggle` import 추가.
  - 각 행의 "활성화"/"비활성화" **S.TableButton** 제거 후, 같은 자리에 **ActiveToggle** 렌더링.
  - `active={notice.active}`, `onToggle={() => onToggleActive(notice.id, notice.active)}`
  - 기존 `onToggleActive`(공지별 활성/비활성 API) 그대로 사용.

### 3.2 전체 활성화 토글 (헤더)

#### `src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeHeader.tsx`

- **수정 내용**
  - `ActiveToggle` import.
  - Props 추가: `sectionAllActive?: boolean`, `onBulkToggleActive?: (targetActive: boolean) => void`.
  - **분반 페이지**(`isSectionPage && currentSection`)일 때, 헤더 오른쪽에 "전체 활성화" + **ActiveToggle** 블록 추가 (수업 링크 복사·새 공지 작성 버튼 앞에 배치).
  - `active={sectionAllActive}`, `onToggle={() => onBulkToggleActive(!sectionAllActive)}`

#### `src/pages/TutorPage/Notices/NoticeManagementPage/styles.ts`

- **수정 내용**
  - `BulkToggleWrap` 스타일 추가 (라벨+토글, 흰색 텍스트).
  - **ActionsInline**의 `gap`을 `0.5rem` → `0.75rem`으로 변경 (수정 버튼과 토글 박스 사이 간격 확대).

#### `src/pages/TutorPage/Notices/NoticeManagementPage/index.tsx`

- **수정 내용**
  - `useNoticeManagement()`에서 `handleBulkToggleActive`, `sectionAllActive` 사용.
  - `NoticeHeader`에 `sectionAllActive={sectionAllActive}`, `onBulkToggleActive={handleBulkToggleActive}` 전달.

#### `src/pages/TutorPage/Notices/NoticeManagementPage/hooks/useNoticeManagement.ts`

- **수정 내용**
  - **handleBulkToggleActive** 추가:
    - `sectionId` 없으면 return.
    - `notices` 순회하며 `notice.active !== targetActive` 인 항목만 `APIService.toggleNoticeActive(notice.id, targetActive)` 호출.
    - 실패 시 알림 후 `fetchNotices()` 하고 종료; 성공 시 마지막에 `fetchNotices()`.
  - **sectionAllActive** 계산:
    - `sectionNotices = sectionId ? notices : []`
    - `sectionAllActive = sectionNotices.length > 0 && sectionNotices.some(n => n.active)`
    - **모든 항목이 비활성일 때만 false(OFF)**, **하나라도 활성이 있으면 true(ON)**.
  - return 객체에 `handleBulkToggleActive`, `sectionAllActive` 추가.

---

## 4. UI/UX 보정

### 4.1 토글–⋯ 버튼 간격

- **파일:** `src/components/UI/ActiveToggle/styles.ts`
- **내용:** `ToggleTrack`에 `margin-right: 6px` 적용 (토글과 옆 ⋯ 버튼이 너무 붙지 않도록, 동시에 너무 멀지 않도록 조정).

### 4.2 공지: 수정 버튼–토글 간격

- **파일:** `src/pages/TutorPage/Notices/NoticeManagementPage/styles.ts`
- **내용:** `ActionsInline`의 `gap`을 `0.5rem` → `0.75rem`으로 변경하여 "수정" 버튼과 토글(SecondaryActions 영역) 사이 간격 확대.

---

## 5. 전체 활성화 토글 표시 로직 요약

| 상태 | 토글 표시 |
|------|------------|
| 해당 분반 항목이 **전부 비활성** | OFF (비활성) |
| 해당 분반 항목 중 **하나라도 활성** | ON (활성) |
| 항목 0개 | OFF |

토글 클릭 시 동작은 기존과 동일하다.

- **ON으로 클릭** → 해당 분반의 모든 항목을 활성으로 변경 (기존 활성/비활성 API를 필요한 만큼 호출).
- **OFF로 클릭** → 해당 분반의 모든 항목을 비활성으로 변경.

---

## 6. 수정 파일 목록 (요약)

| 구분 | 파일 경로 |
|------|-----------|
| 신규 | `src/components/UI/ActiveToggle/index.tsx` |
| 신규 | `src/components/UI/ActiveToggle/styles.ts` |
| 과제 | `src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentManagementHeader.tsx` |
| 과제 | `src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentTableView.tsx` |
| 과제 | `src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentViews/AssignmentListView.tsx` |
| 과제 | `src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts` |
| 과제 | `src/pages/TutorPage/Assignments/AssignmentManagement/styles.ts` |
| 과제 | `src/pages/TutorPage/Assignments/AssignmentManagement/index.tsx` |
| 공지 | `src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeHeader.tsx` |
| 공지 | `src/pages/TutorPage/Notices/NoticeManagementPage/components/NoticeTable.tsx` |
| 공지 | `src/pages/TutorPage/Notices/NoticeManagementPage/hooks/useNoticeManagement.ts` |
| 공지 | `src/pages/TutorPage/Notices/NoticeManagementPage/styles.ts` |
| 공지 | `src/pages/TutorPage/Notices/NoticeManagementPage/index.tsx` |

---

## 7. 백엔드

- 변경 없음. 기존 `toggleAssignmentActive`, `toggleNoticeActive` API를 그대로 사용하며, 전체 활성/비활성은 해당 API를 반복 호출하는 방식으로 구현했다.
