### PR TITLE
fix/issue-142/src/editpage&editmodalfix

### DIFF
--- a/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/styles.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/AssignmentModals/styles.ts
@@ -122,7 +122,9 @@ export const Body = styled.div`
 export const Actions = styled.div`
   display: flex;
   justify-content: flex-end;
+  margin-right: 2rem;
   gap: 1rem;
+  padding-bottom: 2rem;
   padding-top: 1.5rem;
   margin-top: auto;
   border-top: 1px solid #e5e7eb;

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditDescriptionSection.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditDescriptionSection.tsx
@@ -10,6 +10,8 @@ type ProblemEditDescriptionSectionProps = Pick<
 	| "formData"
 	| "setFormData"
 	| "enableFullEdit"
+	| "previewMode"
+	| "setPreviewMode"
 	| "getDescriptionOnlyForPreview"
 	| "getFullPreviewProps"
 	| "insertMarkdownText"
@@ -26,6 +28,8 @@ const ProblemEditDescriptionSection: React.FC<
 	formData,
 	setFormData,
 	enableFullEdit,
+	previewMode,
+	setPreviewMode,
 	getDescriptionOnlyForPreview,
 	getFullPreviewProps,
 	insertMarkdownText,
@@ -65,7 +69,7 @@ const ProblemEditDescriptionSection: React.FC<
 			</S.DescriptionEditor>
 		)}
 
-		{/* 편집 모드: 마크다운 에디터 */}
+		{/* 편집 모드(문제 변환 후): 마크다운 에디터 + 문제 설명만/전체 토글 */}
 		{enableFullEdit && (
 			<S.DescriptionEditor>
 				<S.EditorWrapper>
@@ -239,9 +243,32 @@ const ProblemEditDescriptionSection: React.FC<
 					/>
 				</S.EditorWrapper>
 				<S.Preview>
-					<S.PreviewHeader>미리보기</S.PreviewHeader>
+					<S.PreviewHeader>
+						<span>미리보기</span>
+						<S.PreviewModeToggle>
+							<S.PreviewModeButton
+								type="button"
+								$active={previewMode === "descriptionOnly"}
+								onClick={() => setPreviewMode("descriptionOnly")}
+							>
+								문제 설명만
+							</S.PreviewModeButton>
+							<S.PreviewModeButton
+								type="button"
+								$active={previewMode === "full"}
+								onClick={() => setPreviewMode("full")}
+							>
+								전체
+							</S.PreviewModeButton>
+						</S.PreviewModeToggle>
+					</S.PreviewHeader>
 					<S.PreviewContent>
-						<ProblemPreview {...getFullPreviewProps()} />
+						<ProblemPreview
+							{...(previewMode === "descriptionOnly"
+								? getDescriptionOnlyForPreview()
+								: getFullPreviewProps())}
+							descriptionOnly={previewMode === "descriptionOnly"}
+						/>
 					</S.PreviewContent>
 				</S.Preview>
 			</S.DescriptionEditor>

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
@@ -97,6 +97,8 @@ export default function ProblemEditView(d: ProblemEditHookReturn) {
 							formData={d.formData}
 							setFormData={d.setFormData}
 							enableFullEdit={d.enableFullEdit}
+							previewMode={d.previewMode}
+							setPreviewMode={d.setPreviewMode}
 							getDescriptionOnlyForPreview={d.getDescriptionOnlyForPreview}
 							getFullPreviewProps={d.getFullPreviewProps}
 							insertMarkdownText={d.insertMarkdownText}

--- a/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
@@ -60,6 +60,8 @@ export function useProblemEdit() {
 	const [originalTimeLimit, setOriginalTimeLimit] = useState("");
 	const [originalMemoryLimit, setOriginalMemoryLimit] = useState("");
 	const [enableFullEdit, setEnableFullEdit] = useState(false);
+	/** "descriptionOnly" = 문제 설명만, "full" = 전체(입력/출력/예제 포함) */
+	const [previewMode, setPreviewMode] = useState<"descriptionOnly" | "full">("full");
 	const [parsedTestCases, setParsedTestCases] = useState<ParsedTestcase[]>([]);
 	const [showParsedTestCases, setShowParsedTestCases] = useState(false);
 
@@ -771,6 +773,8 @@ export function useProblemEdit() {
 		handleParsedTestcaseRemove,
 		handleParsedTestcaseChange,
 		getFullDescription,
+		previewMode,
+		setPreviewMode,
 		getDescriptionOnlyForPreview,
 		getFullPreviewProps,
 		insertMarkdownText,

--- a/src/pages/TutorPage/Problems/ProblemEdit/styles.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/styles.ts
@@ -253,12 +253,39 @@ export const Preview = styled.div`
 `;
 
 export const PreviewHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 0.75rem 1rem;
   background: #f8fafc;
   border-bottom: 1px solid #e2e8f0;
   font-weight: 500;
   font-size: 0.875rem;
   color: #64748b;
+`;
+
+export const PreviewModeToggle = styled.div`
+  display: flex;
+  gap: 0;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid #e2e8f0;
+  background: white;
+`;
+
+export const PreviewModeButton = styled.button<{ $active?: boolean }>`
+  padding: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: none;
+  background: ${(p) => (p.$active ? "#667eea" : "transparent")};
+  color: ${(p) => (p.$active ? "white" : "#64748b")};
+  cursor: pointer;
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: ${(p) => (p.$active ? "#5a67d8" : "#f1f5f9")};
+  }
 `;
 
 export const PreviewContent = styled.div`


### PR DESCRIPTION
## #️⃣연관된 이슈

> #142 

## 📝작업 내용
## 이슈 #142 – 문제 수정 페이지 미리보기 토글 및 UI 수정

### 요약
- 문제 **수정** 페이지(`/tutor/problems/:id/edit`)에서도 **문제 생성** 페이지와 동일하게 미리보기 **「문제 설명만 / 전체」** 토글을 사용할 수 있도록 수정했습니다.
- 해당 토글은 **문제 변환(편집 모드)을 켠 뒤에만** 노출되도록 했습니다.

### 변경 사항

#### 1. 문제 수정 페이지 – 미리보기 토글 (문제 변환 후만)
- **문제 변환** 버튼을 누른 후(편집 모드)에만 미리보기 영역에 **「문제 설명만」 | 「전체」** 토글 버튼 표시.
- **문제 설명만**: 본문만 미리보기 (입력 형식·출력 형식·예제 숨김).
- **전체**: 본문 + 입력 형식 + 출력 형식 + 예제 모두 미리보기.
- 문제 변환 전(읽기 전용)에는 토글 없이 기존처럼 전체 미리보기만 표시.

#### 2. 수정된 파일
| 파일 | 내용 |
|------|------|
| `ProblemEdit/hooks/useProblemEdit.ts` | `previewMode`, `setPreviewMode` state 추가 및 반환 |
| `ProblemEdit/styles.ts` | `PreviewHeader`(flex 정렬), `PreviewModeToggle`, `PreviewModeButton` 스타일 추가 |
| `ProblemEdit/components/ProblemEditDescriptionSection.tsx` | 읽기 전용 시에는 토글 없음 / 편집 모드 시 미리보기 헤더에 토글 + `previewMode`에 따라 `ProblemPreview`에 전달하는 props 분기 |
| `ProblemEdit/components/ProblemEditView.tsx` | `ProblemEditDescriptionSection`에 `previewMode`, `setPreviewMode` 전달 |
| `AssignmentManagement/AssignmentModals/styles.ts` | (해당 브랜치에서 함께 수정된 스타일 반영) |

### 동작 정리
- **문제 변환 전**: 미리보기 헤더는 "미리보기"만, 내용은 항상 전체 미리보기.
- **문제 변환 후**: 미리보기 헤더에 「문제 설명만」「전체」 토글 표시, 선택에 따라 미리보기 내용 전환.

### 테스트 방법
1. `/tutor/problems/:id/edit` 접속.
2. 문제 변환 전: 미리보기에 토글이 없고 전체만 보이는지 확인.
3. 「문제 변환 모드 활성화」 후: 미리보기 우측에 「문제 설명만」「전체」 토글이 보이고, 전환 시 미리보기 내용이 바뀌는지 확인.