### PR TITLE
feat/issue-144/src/20260310feedbackdone

### DIFF
--- a/src/components/Course/CourseCard/index.tsx
+++ b/src/components/Course/CourseCard/index.tsx
@@ -31,6 +31,8 @@ interface CourseCardProps {
 	onEnroll?: () => void;
 	/** true면 분반 배지 숨김 (예: /courses 참여한 수업 목록) */
 	hideBatch?: boolean;
+	/** 지정 시 카드 클릭 시 이 경로로 이동 (예: 관리 중인 수업 → /tutor/assignments/section/:id) */
+	overrideLinkPath?: string;
 }
 
 const CourseCard: React.FC<CourseCardProps> = ({
@@ -39,10 +41,14 @@ const CourseCard: React.FC<CourseCardProps> = ({
 	showEnrollButton = false,
 	onEnroll,
 	hideBatch = false,
+	overrideLinkPath,
 }) => {
 	const navigate = useNavigate();
 
 	const getLinkPath = () => {
+		if (overrideLinkPath) {
+			return overrideLinkPath;
+		}
 		if (course.sectionId) {
 			return `/sections/${course.sectionId}/dashboard`;
 		}

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx
@@ -150,13 +150,23 @@ export default function CourseAssignmentsPageView(
 																}
 															>
 																<S.ProblemTitle>{problem.title}</S.ProblemTitle>
-																<S.ProblemBadge $status={problem.status} $late={problem.status !== "NOT_SUBMITTED" && problem.isOnTime === false}>
-																	{problem.status === "ACCEPTED"
-																		? (problem.isOnTime === false ? "지각 정답" : "정답")
-																		: problem.status === "SUBMITTED"
-																			? (problem.isOnTime === false ? "지각 제출" : "제출")
-																			: "미제출"}
-																</S.ProblemBadge>
+																<S.ProblemStatusBlock>
+																	<S.ProblemBadge $status={problem.status} $late={problem.status !== "NOT_SUBMITTED" && problem.isOnTime === false}>
+																		{problem.status === "ACCEPTED"
+																			? (problem.isOnTime === false ? "지각 정답" : "정답")
+																			: problem.status === "SUBMITTED"
+																				? (problem.isOnTime === false ? "지각 제출" : "제출")
+																				: "미제출"}
+																	</S.ProblemBadge>
+																	{problem.status !== "NOT_SUBMITTED" && problem.submittedAt && (
+																		<S.ProblemSubmissionMeta>
+																			<span>{d.formatSubmissionTime(problem.submittedAt)}</span>
+																			{problem.isOnTime === false && problem.minutesLate != null && (
+																				<S.LateMinutes>· {d.formatMinutesLate(problem.minutesLate)}</S.LateMinutes>
+																			)}
+																		</S.ProblemSubmissionMeta>
+																	)}
+																</S.ProblemStatusBlock>
 															</S.AccordionProblemItem>
 														))}
 													</S.AccordionProblemsList>

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts
@@ -114,7 +114,13 @@ export function useCourseAssignmentsPage() {
 								}) => {
 									const statusEntry = problemsStatus.find(
 										(s: { problemId: number }) => s.problemId === problem.id,
-									) as { problemId: number; status: string; isOnTime?: boolean } | undefined;
+									) as {
+										problemId: number;
+										status: string;
+										isOnTime?: boolean;
+										submittedAt?: string;
+										minutesLate?: number;
+									} | undefined;
 									const raw = statusEntry
 										? statusEntry.status
 										: "NOT_SUBMITTED";
@@ -125,6 +131,12 @@ export function useCourseAssignmentsPage() {
 									const submitted =
 										problemStatus === "SUBMITTED" ||
 										problemStatus === "ACCEPTED";
+									const submittedAt =
+										statusEntry?.submittedAt != null
+											? typeof statusEntry.submittedAt === "string"
+												? statusEntry.submittedAt
+												: new Date(statusEntry.submittedAt).toISOString()
+											: undefined;
 									return {
 										id: problem.id,
 										title: problem.title,
@@ -132,6 +144,8 @@ export function useCourseAssignmentsPage() {
 										submitted,
 										status: problemStatus,
 										isOnTime: statusEntry?.isOnTime,
+										submittedAt,
+										minutesLate: statusEntry?.minutesLate,
 									};
 								},
 							);
@@ -233,6 +247,32 @@ export function useCourseAssignmentsPage() {
 		return `${year}.${month}.${day} ${hours}:${minutes}`;
 	}, []);
 
+	/** 제출 시각을 "YYYY.MM.DD HH:mm"으로 표시 */
+	const formatSubmissionTime = useCallback((dateString: string | undefined): string => {
+		if (!dateString?.trim()) return "";
+		const date = new Date(dateString);
+		if (Number.isNaN(date.getTime())) return "";
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, "0");
+		const day = String(date.getDate()).padStart(2, "0");
+		const hours = String(date.getHours()).padStart(2, "0");
+		const minutes = String(date.getMinutes()).padStart(2, "0");
+		return `${year}.${month}.${day} ${hours}:${minutes}`;
+	}, []);
+
+	/** 지각 분 수를 "N일 N시간 N분 늦음" 형식으로 표시 (0인 단위는 생략) */
+	const formatMinutesLate = useCallback((totalMinutes: number): string => {
+		if (totalMinutes < 0) return "";
+		const days = Math.floor(totalMinutes / (60 * 24));
+		const hours = Math.floor((totalMinutes % (60 * 24)) / 60);
+		const mins = totalMinutes % 60;
+		const parts: string[] = [];
+		if (days > 0) parts.push(`${days}일`);
+		if (hours > 0) parts.push(`${hours}시간`);
+		if (mins > 0 || parts.length === 0) parts.push(`${mins}분`);
+		return `${parts.join(" ")} 늦음`;
+	}, []);
+
 	const handleMenuClick = useCallback(
 		(menuId: string) => {
 			switch (menuId) {
@@ -277,6 +317,8 @@ export function useCourseAssignmentsPage() {
 		toggleAssignment,
 		formatDate,
 		formatDeadline,
+		formatSubmissionTime,
+		formatMinutesLate,
 		handleMenuClick,
 		handleProblemClick,
 		handleToggleSidebar,

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/styles.ts
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/styles.ts
@@ -293,6 +293,13 @@ export const ProblemTitle = styled.span`
   flex: 1;
 `;
 
+export const ProblemStatusBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+`;
+
 export const ProblemBadge = styled.span<{ $status: ProblemStatus; $late?: boolean }>`
   font-size: 12px;
   font-weight: 600;
@@ -310,6 +317,19 @@ export const ProblemBadge = styled.span<{ $status: ProblemStatus; $late?: boolea
     props.$status === "ACCEPTED" || props.$status === "SUBMITTED" || props.$late
       ? "#FFFFFF"
       : "#888888"};
+`;
+
+export const ProblemSubmissionMeta = styled.div`
+  font-size: 12px;
+  color: #666666;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const LateMinutes = styled.span`
+  color: #c2410c;
+  font-weight: 600;
 `;
 
 export const NoAssignmentsMessage = styled.div`

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/types.ts
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/types.ts
@@ -8,6 +8,10 @@ export interface Problem {
 	status: ProblemStatus;
 	/** 제출 시 마감일 이전 여부 (미제출이면 undefined) */
 	isOnTime?: boolean;
+	/** 제출 시각 ISO 문자열 (미제출이면 undefined) */
+	submittedAt?: string;
+	/** 지각 제출 시 마감 대비 늦은 분 수 (제시간/미제출이면 undefined) */
+	minutesLate?: number;
 }
 
 export interface Assignment {

--- a/src/pages/Course/ClassPage/components/ClassPageView.tsx
+++ b/src/pages/Course/ClassPage/components/ClassPageView.tsx
@@ -113,6 +113,11 @@ export default function ClassPageView(d: ClassPageHookReturn) {
 											}
 										: undefined
 								}
+								overrideLinkPath={
+									d.activeTab === "in-progress" && course.sectionId
+										? `/tutor/assignments/section/${course.sectionId}`
+										: undefined
+								}
 							/>
 						))}
 					</S.CoursesGrid>

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/ProblemSelectModal.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/ProblemSelectModal.tsx
@@ -480,8 +480,7 @@ const ProblemSelectModal: React.FC<ProblemSelectModalProps> = ({
 										<span>전체 선택</span>
 									</label>
 									<S.ItemCount>
-										{selectedProblemIds.length} / {currentProblems.length}개
-										선택됨
+										{selectedProblemIds.length} / {currentProblems.length}개 선택됨
 									</S.ItemCount>
 								</div>
 							)}

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts
@@ -481,20 +481,11 @@ export function useAssignmentManagement() {
 		[selectedAssignment, refetchAssignments],
 	);
 
-	const existingProblemIds = new Set(
-		(selectedAssignment?.problems ?? []).map((p: { id: number }) => p.id),
-	);
-	const existingProblemTitles = new Set(
-		(selectedAssignment?.problems ?? [])
-			.map((p: { title?: string }) => p.title)
-			.filter(Boolean),
-	);
-
 	const filteredProblems = availableProblems.filter(
 		(problem: { id: number; title?: string }) =>
-			problem.title?.toLowerCase().includes(problemSearchTerm.toLowerCase()) &&
-			!existingProblemIds.has(problem.id) &&
-			!(problem.title && existingProblemTitles.has(problem.title)),
+			(problem.title ?? "")
+				.toLowerCase()
+				.includes(problemSearchTerm.toLowerCase()),
 	);
 
 	const handleProblemToggle = useCallback((problemId: number) => {
@@ -627,7 +618,15 @@ export function useAssignmentManagement() {
 				const parsed = await APIService.parseZipFile(fd);
 				const testCases = parsed?.testCases ?? parsed?.testcases ?? [];
 				const testcases = testCases.map(
-					(tc: { name?: string; input?: string; output?: string; type?: string }, idx: number) => ({
+					(
+						tc: {
+							name?: string;
+							input?: string;
+							output?: string;
+							type?: string;
+						},
+						idx: number,
+					) => ({
 						name: tc.name ?? `testcase_${idx}`,
 						input: tc.input ?? "",
 						output: tc.output ?? "",
@@ -728,7 +727,15 @@ export function useAssignmentManagement() {
 				const parsed = await APIService.parseZipFile(fd);
 				const testCases = parsed?.testCases ?? parsed?.testcases ?? [];
 				const testcases = testCases.map(
-					(tc: { name?: string; input?: string; output?: string; type?: string }, idx: number) => ({
+					(
+						tc: {
+							name?: string;
+							input?: string;
+							output?: string;
+							type?: string;
+						},
+						idx: number,
+					) => ({
 						name: tc.name ?? `testcase_${idx}`,
 						input: tc.input ?? "",
 						output: tc.output ?? "",
@@ -864,7 +871,15 @@ export function useAssignmentManagement() {
 					const parsed = await APIService.parseZipFile(fd);
 					const testCases = parsed?.testCases ?? parsed?.testcases ?? [];
 					const testcases = testCases.map(
-						(tc: { name?: string; input?: string; output?: string; type?: string }, idx: number) => ({
+						(
+							tc: {
+								name?: string;
+								input?: string;
+								output?: string;
+								type?: string;
+							},
+							idx: number,
+						) => ({
 							name: tc.name ?? `testcase_${idx}`,
 							input: tc.input ?? "",
 							output: tc.output ?? "",
@@ -926,8 +941,10 @@ export function useAssignmentManagement() {
 			return matchSearch && matchSection;
 		})
 		.sort((a: Assignment, b: Assignment) => {
-			const dueA = a.dueDate ?? (a as Assignment & { endDate?: string }).endDate ?? "";
-			const dueB = b.dueDate ?? (b as Assignment & { endDate?: string }).endDate ?? "";
+			const dueA =
+				a.dueDate ?? (a as Assignment & { endDate?: string }).endDate ?? "";
+			const dueB =
+				b.dueDate ?? (b as Assignment & { endDate?: string }).endDate ?? "";
 			const timeA = dueA ? new Date(dueA).getTime() : Number.MAX_SAFE_INTEGER;
 			const timeB = dueB ? new Date(dueB).getTime() : Number.MAX_SAFE_INTEGER;
 			return timeA - timeB;

--- a/src/pages/TutorPage/Dashboard/components/SectionCard.tsx
+++ b/src/pages/TutorPage/Dashboard/components/SectionCard.tsx
@@ -95,7 +95,6 @@ const SectionCard: React.FC<SectionCardProps> = ({
 						성적
 					</S.ActionButton>
 					<S.ActionButton
-						$primary
 						onClick={() =>
 							navigate(`/tutor/assignments/section/${section.sectionId}`)
 						}

--- a/src/pages/TutorPage/Dashboard/hooks/useDashboard.ts
+++ b/src/pages/TutorPage/Dashboard/hooks/useDashboard.ts
@@ -163,8 +163,16 @@ export function useDashboard() {
 		sectionId: number,
 		currentActive: boolean,
 	) => {
+		const newActive = !currentActive;
+		const message = newActive
+			? "이 수업을 활성화하시겠습니까?"
+			: "이 수업을 비활성화하시겠습니까?";
+
+		if (!window.confirm(message)) {
+			return;
+		}
+
 		try {
-			const newActive = !currentActive;
 			await APIService.toggleSectionActive(sectionId, newActive);
 			alert(
 				newActive ? "수업이 활성화되었습니다." : "수업이 비활성화되었습니다.",

--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementAssignmentTable.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementAssignmentTable.tsx
@@ -46,6 +46,13 @@ export default function GradeManagementAssignmentTable({
 		selectedAssignment?.endDate ??
 		selectedAssignment?.deadline;
 
+	const submissionTitle = (label: string, submittedAt?: string) =>
+		submittedAt
+			? `${label} · 제출: ${new Date(submittedAt).toLocaleString("ko-KR")}`
+			: label;
+	const getSubmittedAt = (p: { submittedAt?: string; submitted_at?: string }) =>
+		p.submittedAt ?? p.submitted_at;
+
 	return (
 		<S.CourseTableContainer>
 			<S.GradeLegend>
@@ -161,14 +168,20 @@ export default function GradeManagementAssignmentTable({
 														(problem.submitted ? (
 															<S.SubmissionStatus $onTime={problem.isOnTime} $late={!problem.isOnTime}>
 																{problem.isOnTime ? (
-																	<FaCheckCircle title="제시간 제출" />
+																	<span title={submissionTitle("제시간 제출", getSubmittedAt(problem))}>
+																		<FaCheckCircle />
+																	</span>
 																) : (
-																	<FaExclamationTriangle title="지각 제출" />
+																	<span title={submissionTitle("지각 제출", getSubmittedAt(problem))}>
+																		<FaExclamationTriangle />
+																	</span>
 																)}
 															</S.SubmissionStatus>
 														) : (
 															<S.SubmissionStatus $onTime={false} $late={false}>
-																<FaTimesCircle title="미제출" />
+																<span title="미제출">
+																	<FaTimesCircle />
+																</span>
 															</S.SubmissionStatus>
 														))}
 												</S.ScoreRow>

--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementCourseTable.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementCourseTable.tsx
@@ -47,6 +47,11 @@ export interface GradeManagementCourseTableProps {
 	onProblemDetail?: (problemId: number) => void;
 }
 
+const submissionTitle = (label: string, submittedAt?: string) =>
+	submittedAt
+		? `${label} · 제출: ${new Date(submittedAt).toLocaleString("ko-KR")}`
+		: label;
+
 export default function GradeManagementCourseTable({
 	courseLoading,
 	courseGrades,
@@ -269,14 +274,20 @@ export default function GradeManagementCourseTable({
 																						$late={!problemGrade.isOnTime}
 																					>
 																						{problemGrade.isOnTime ? (
-																							<FaCheckCircle title="제시간 제출" />
+																							<span title={submissionTitle("제시간 제출", problemGrade.submittedAt)}>
+																								<FaCheckCircle />
+																							</span>
 																						) : (
-																							<FaExclamationTriangle title="지각 제출" />
+																							<span title={submissionTitle("지각 제출", problemGrade.submittedAt)}>
+																								<FaExclamationTriangle />
+																							</span>
 																						)}
 																					</S.SubmissionStatus>
 																				) : (
 																					<S.SubmissionStatus $onTime={false} $late={false}>
-																						<FaTimesCircle title="미제출" />
+																						<span title="미제출">
+																							<FaTimesCircle />
+																						</span>
 																					</S.SubmissionStatus>
 																				))}
 																		</S.ScoreRow>
@@ -342,14 +353,20 @@ export default function GradeManagementCourseTable({
 																					$late={!problemGrade.isOnTime}
 																				>
 																					{problemGrade.isOnTime ? (
-																						<FaCheckCircle title="제시간 제출" />
+																						<span title={submissionTitle("제시간 제출", problemGrade.submittedAt)}>
+																							<FaCheckCircle />
+																						</span>
 																					) : (
-																						<FaExclamationTriangle title="지각 제출" />
+																						<span title={submissionTitle("지각 제출", problemGrade.submittedAt)}>
+																							<FaExclamationTriangle />
+																						</span>
 																					)}
 																				</S.SubmissionStatus>
 																			) : (
 																				<S.SubmissionStatus $onTime={false} $late={false}>
-																					<FaTimesCircle title="미제출" />
+																					<span title="미제출">
+																						<FaTimesCircle />
+																					</span>
 																				</S.SubmissionStatus>
 																			))}
 																	</S.ScoreRow>

--- a/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementQuizTable.tsx
+++ b/src/pages/TutorPage/Grades/GradeManagement/components/GradeManagementQuizTable.tsx
@@ -50,6 +50,13 @@ export default function GradeManagementQuizTable({
 	const problemGrades = grades[0]?.problemGrades ?? [];
 	const quizTitle = selectedQuiz?.title ?? "퀴즈";
 
+	const submissionTitle = (label: string, submittedAt?: string) =>
+		submittedAt
+			? `${label} · 제출: ${new Date(submittedAt).toLocaleString("ko-KR")}`
+			: label;
+	const getSubmittedAt = (p: { submittedAt?: string; submitted_at?: string }) =>
+		p.submittedAt ?? p.submitted_at;
+
 	return (
 		<S.CourseTableContainer>
 			<S.GradeLegend>
@@ -146,14 +153,20 @@ export default function GradeManagementQuizTable({
 													(problem.submitted ? (
 														<S.SubmissionStatus $onTime={problem.isOnTime} $late={!problem.isOnTime}>
 															{problem.isOnTime ? (
-																<FaCheckCircle title="제시간 제출" />
+																<span title={submissionTitle("제시간 제출", getSubmittedAt(problem))}>
+																	<FaCheckCircle />
+																</span>
 															) : (
-																<FaExclamationTriangle title="지각 제출" />
+																<span title={submissionTitle("지각 제출", getSubmittedAt(problem))}>
+																	<FaExclamationTriangle />
+																</span>
 															)}
 														</S.SubmissionStatus>
 													) : (
 														<S.SubmissionStatus $onTime={false} $late={false}>
-															<FaTimesCircle title="미제출" />
+															<span title="미제출">
+																<FaTimesCircle />
+															</span>
 														</S.SubmissionStatus>
 													))}
 											</S.ScoreRow>

--- a/src/pages/TutorPage/Problems/ProblemCreate/components/ProblemCreateView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemCreate/components/ProblemCreateView.tsx
@@ -536,7 +536,7 @@ export default function ProblemCreateView(d: ProblemCreateHookReturn) {
 										파일 선택
 									</S.FileLabelInline>
 									<S.HelpText>
-										테스트케이스 입력(.in) 및 출력(.ans) 파일
+										테스트케이스 입력(.in) 및 출력(.ans) 파일 · 아래에서 직접 입력도 가능
 									</S.HelpText>
 								</S.FileUploadWrapper>
 								<S.TestcaseList>
@@ -552,6 +552,124 @@ export default function ProblemCreateView(d: ProblemCreateHookReturn) {
 										</S.TestcaseItem>
 									))}
 								</S.TestcaseList>
+
+								<div style={{ marginTop: "1rem" }}>
+									<button
+										type="button"
+										onClick={d.handleManualTestcaseAdd}
+										style={{
+											padding: "8px 14px",
+											borderRadius: "6px",
+											border: "1px solid #cbd5e1",
+											background: "#f8fafc",
+											cursor: "pointer",
+											fontSize: "14px",
+										}}
+									>
+										+ 테스트케이스 직접 추가
+									</button>
+								</div>
+								{d.manualTestCases.length > 0 && (
+									<S.ParsedTestcasesSection style={{ marginTop: "1rem" }}>
+										<S.Label style={{ marginBottom: "0.5rem" }}>
+											직접 추가한 테스트케이스 ({d.manualTestCases.length}개)
+										</S.Label>
+										<S.ParsedTestcases>
+											{d.manualTestCases.map((tc, idx) => (
+												<S.ParsedTestcaseItem key={idx}>
+													<S.ParsedTestcaseHeader>
+														<span style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+															<input
+																type="text"
+																value={tc.name ?? ""}
+																onChange={(e) =>
+																	d.handleManualTestcaseChange(idx, "name", e.target.value)
+																}
+																placeholder="이름"
+																style={{
+																	width: "120px",
+																	padding: "0.35rem 0.5rem",
+																	fontSize: "0.9rem",
+																	border: "1px solid #cbd5e1",
+																	borderRadius: "4px",
+																}}
+															/>
+															<select
+																value={tc.type ?? "secret"}
+																onChange={(e) =>
+																	d.handleManualTestcaseChange(
+																		idx,
+																		"type",
+																		e.target.value as "sample" | "secret",
+																	)
+																}
+																style={{
+																	padding: "0.35rem 0.5rem",
+																	borderRadius: "4px",
+																	border: "1px solid #cbd5e1",
+																	fontSize: "0.85rem",
+																}}
+															>
+																<option value="sample">샘플</option>
+																<option value="secret">비밀</option>
+															</select>
+														</span>
+														<S.TestcaseRemove
+															type="button"
+															onClick={() => d.handleManualTestcaseRemove(idx)}
+														>
+															×
+														</S.TestcaseRemove>
+													</S.ParsedTestcaseHeader>
+													<S.ParsedTestcaseContent>
+														<div>
+															<strong>입력:</strong>
+															<textarea
+																value={tc.input ?? ""}
+																onChange={(e) =>
+																	d.handleManualTestcaseChange(idx, "input", e.target.value)
+																}
+																rows={3}
+																placeholder="입력 데이터"
+																style={{
+																	width: "100%",
+																	fontFamily: "monospace",
+																	fontSize: "0.85rem",
+																	padding: "8px",
+																	border: "1px solid #e2e8f0",
+																	borderRadius: "4px",
+																	marginTop: "4px",
+																	resize: "vertical",
+																}}
+															/>
+														</div>
+														<div>
+															<strong>출력:</strong>
+															<textarea
+																value={tc.output ?? ""}
+																onChange={(e) =>
+																	d.handleManualTestcaseChange(idx, "output", e.target.value)
+																}
+																rows={3}
+																placeholder="출력 데이터"
+																style={{
+																	width: "100%",
+																	fontFamily: "monospace",
+																	fontSize: "0.85rem",
+																	padding: "8px",
+																	border: "1px solid #e2e8f0",
+																	borderRadius: "4px",
+																	marginTop: "4px",
+																	resize: "vertical",
+																}}
+															/>
+														</div>
+													</S.ParsedTestcaseContent>
+												</S.ParsedTestcaseItem>
+											))}
+										</S.ParsedTestcases>
+									</S.ParsedTestcasesSection>
+								)}
 
 								{d.parsedTestCases.length > 0 && (
 									<S.ParsedTestcasesSection>

--- a/src/pages/TutorPage/Problems/ProblemCreate/hooks/useProblemCreate.ts
+++ b/src/pages/TutorPage/Problems/ProblemCreate/hooks/useProblemCreate.ts
@@ -103,6 +103,7 @@ export function useProblemCreate() {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [parsedTestCases, setParsedTestCases] = useState<ParsedTestcase[]>([]);
+	const [manualTestCases, setManualTestCases] = useState<ParsedTestcase[]>([]);
 	const [showParsedTestCases, setShowParsedTestCases] = useState(false);
 	const [formData, setFormData] = useState<ProblemFormData>(initialFormData);
 	const [currentTag, setCurrentTag] = useState("");
@@ -380,6 +381,30 @@ export function useProblemCreate() {
 		setFieldErrors((prev) => ({ ...prev, testcases: false }));
 	}, []);
 
+	const handleManualTestcaseAdd = useCallback(() => {
+		setManualTestCases((prev) => [
+			...prev,
+			{ name: `테스트케이스 ${prev.length + 1}`, input: "", output: "", type: "secret" },
+		]);
+		setFieldErrors((prev) => ({ ...prev, testcases: false }));
+	}, []);
+
+	const handleManualTestcaseRemove = useCallback((index: number) => {
+		setManualTestCases((prev) => prev.filter((_, i) => i !== index));
+		setFieldErrors((prev) => ({ ...prev, testcases: false }));
+	}, []);
+
+	const handleManualTestcaseChange = useCallback(
+		(index: number, field: keyof ParsedTestcase, value: string) => {
+			setManualTestCases((prev) => {
+				const next = [...prev];
+				if (next[index]) next[index] = { ...next[index], [field]: value };
+				return next;
+			});
+		},
+		[],
+	);
+
 	/** 커서 위치에 텍스트를 삽입하고 description 상태를 동기화합니다. */
 	const insertMarkdownText = useCallback((text: string) => {
 		const el = descriptionRef.current;
@@ -523,7 +548,11 @@ export function useProblemCreate() {
 			const hasTestcases =
 				parsedTestCases.some(
 					(tc) => (tc.input?.trim() && tc.output?.trim()),
-				) || formData.testcases.length > 0;
+				) ||
+				formData.testcases.length > 0 ||
+				manualTestCases.some(
+					(tc) => (tc.input?.trim() && tc.output?.trim()),
+				);
 			if (!hasTestcases) errs.testcases = true;
 
 			setFieldErrors(errs);
@@ -550,9 +579,18 @@ export function useProblemCreate() {
 					}));
 
 				const testcasesFromFiles = await filesToTestCases(formData.testcases);
+				const testcasesFromManual: TestCaseDto[] = manualTestCases
+					.filter((tc) => tc.input?.trim() && tc.output?.trim())
+					.map((tc, idx) => ({
+						name: tc.name ?? `testcase_manual_${idx}`,
+						input: tc.input ?? "",
+						output: tc.output ?? "",
+						type: (tc.type === "sample" ? "sample" : "secret") as "sample" | "secret",
+					}));
 				const testcases: TestCaseDto[] = [
 					...testcasesFromParsed,
 					...testcasesFromFiles,
+					...testcasesFromManual,
 				];
 
 				const request: ProblemCreateRequest = {
@@ -604,6 +642,7 @@ export function useProblemCreate() {
 		[
 			formData,
 			parsedTestCases,
+			manualTestCases,
 			getFullDescriptionForBackend,
 			navigate,
 			locationState,
@@ -651,6 +690,10 @@ export function useProblemCreate() {
 		handleTestcaseAdd,
 		handleTestcaseRemove,
 		handleParsedTestcaseRemove,
+		manualTestCases,
+		handleManualTestcaseAdd,
+		handleManualTestcaseRemove,
+		handleManualTestcaseChange,
 		insertMarkdownText,
 		wrapWithMarkdown,
 		insertMarkdownHeading,

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditTestcasesSection.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditTestcasesSection.tsx
@@ -10,6 +10,7 @@ type ProblemEditTestcasesSectionProps = Pick<
 	| "showParsedTestCases"
 	| "setShowParsedTestCases"
 	| "handleTestcaseAdd"
+	| "handleTestcaseAddManual"
 	| "handleTestcaseRemove"
 	| "handleTestcaseChange"
 	| "handleParsedTestcaseRemove"
@@ -25,6 +26,7 @@ const ProblemEditTestcasesSection: React.FC<
 	showParsedTestCases,
 	setShowParsedTestCases,
 	handleTestcaseAdd,
+	handleTestcaseAddManual,
 	handleTestcaseRemove,
 	handleTestcaseChange,
 	handleParsedTestcaseRemove,
@@ -33,7 +35,7 @@ const ProblemEditTestcasesSection: React.FC<
 	<>
 		{enableFullEdit && (
 			<S.Fieldset aria-labelledby="problem-edit-testcase-label">
-				<S.Legend id="problem-edit-testcase-label">테스트케이스 파일</S.Legend>
+				<S.Legend id="problem-edit-testcase-label">테스트케이스</S.Legend>
 				<S.FileUploadWrapper>
 					<S.FileInput
 						type="file"
@@ -42,7 +44,22 @@ const ProblemEditTestcasesSection: React.FC<
 						accept=".in,.ans"
 						onChange={handleTestcaseAdd}
 					/>
-					<S.FileLabelInline htmlFor="testcaseInput">추가</S.FileLabelInline>
+					<S.FileLabelInline htmlFor="testcaseInput">파일 추가</S.FileLabelInline>
+					<button
+						type="button"
+						onClick={handleTestcaseAddManual}
+						style={{
+							marginLeft: "8px",
+							padding: "6px 12px",
+							borderRadius: "6px",
+							border: "1px solid #cbd5e1",
+							background: "#f8fafc",
+							cursor: "pointer",
+							fontSize: "13px",
+						}}
+					>
+						직접 추가
+					</button>
 					<S.HelpText
 						style={{
 							display: "block",
@@ -62,9 +79,22 @@ const ProblemEditTestcasesSection: React.FC<
 							>
 								<S.TestcaseHeaderCompact>
 									<S.TestcaseHeaderLeft>
-										<S.TestcaseName>
-											{testcase.name ?? `테스트케이스 ${idx + 1}`}
-										</S.TestcaseName>
+										<input
+											type="text"
+											value={testcase.name ?? ""}
+											onChange={(e) =>
+												handleTestcaseChange(idx, "name", e.target.value)
+											}
+											placeholder={`테스트케이스 ${idx + 1}`}
+											style={{
+												fontSize: "inherit",
+												fontWeight: 600,
+												padding: "4px 8px",
+												border: "1px solid #e2e8f0",
+												borderRadius: "4px",
+												minWidth: "140px",
+											}}
+										/>
 										<S.TestcaseTypeSelect
 											value={testcase.type ?? "secret"}
 											onChange={(e) =>
@@ -86,22 +116,46 @@ const ProblemEditTestcasesSection: React.FC<
 									</S.TestcaseRemoveBtn>
 								</S.TestcaseHeaderCompact>
 								<S.TestcaseBodyCompact>
-									{testcase.input && (
-										<S.TestcaseContentItem>
-											<S.TestcaseContentLabel>입력</S.TestcaseContentLabel>
-											<S.TestcaseContentText>
-												{testcase.input}
-											</S.TestcaseContentText>
-										</S.TestcaseContentItem>
-									)}
-									{testcase.output && (
-										<S.TestcaseContentItem>
-											<S.TestcaseContentLabel>출력</S.TestcaseContentLabel>
-											<S.TestcaseContentText>
-												{testcase.output}
-											</S.TestcaseContentText>
-										</S.TestcaseContentItem>
-									)}
+									<S.TestcaseContentItem>
+										<S.TestcaseContentLabel>입력</S.TestcaseContentLabel>
+										<textarea
+											value={testcase.input ?? ""}
+											onChange={(e) =>
+												handleTestcaseChange(idx, "input", e.target.value)
+											}
+											placeholder="입력 데이터"
+											rows={3}
+											style={{
+												width: "100%",
+												fontFamily: "monospace",
+												fontSize: "13px",
+												padding: "8px",
+												border: "1px solid #e2e8f0",
+												borderRadius: "6px",
+												resize: "vertical",
+											}}
+										/>
+									</S.TestcaseContentItem>
+									<S.TestcaseContentItem>
+										<S.TestcaseContentLabel>출력</S.TestcaseContentLabel>
+										<textarea
+											value={testcase.output ?? ""}
+											onChange={(e) =>
+												handleTestcaseChange(idx, "output", e.target.value)
+											}
+											placeholder="출력 데이터"
+											rows={3}
+											style={{
+												width: "100%",
+												fontFamily: "monospace",
+												fontSize: "13px",
+												padding: "8px",
+												border: "1px solid #e2e8f0",
+												borderRadius: "6px",
+												resize: "vertical",
+											}}
+										/>
+									</S.TestcaseContentItem>
 								</S.TestcaseBodyCompact>
 							</S.TestcaseItemCompact>
 						))}

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
@@ -127,6 +127,7 @@ export default function ProblemEditView(d: ProblemEditHookReturn) {
 								showParsedTestCases={d.showParsedTestCases}
 								setShowParsedTestCases={d.setShowParsedTestCases}
 						handleTestcaseAdd={d.handleTestcaseAdd}
+							handleTestcaseAddManual={d.handleTestcaseAddManual}
 							handleTestcaseRemove={d.handleTestcaseRemove}
 							handleTestcaseChange={d.handleTestcaseChange}
 							handleParsedTestcaseRemove={d.handleParsedTestcaseRemove}

--- a/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
@@ -431,6 +431,26 @@ export function useProblemEdit() {
 		[formData.testcases, parsedTestCases],
 	);
 
+	const handleTestcaseAddManual = useCallback(() => {
+		const n =
+			formData.testcases.length +
+			parsedTestCases.length +
+			1;
+		setFormData((prev) => ({
+			...prev,
+			testcases: [
+				...prev.testcases,
+				{
+					name: `테스트케이스 ${n}`,
+					input: "",
+					output: "",
+					type: "secret" as const,
+					isNew: true,
+				},
+			],
+		}));
+	}, [formData.testcases.length, parsedTestCases.length]);
+
 	const handleTestcaseRemove = useCallback((index: number) => {
 		setFormData((prev) => ({
 			...prev,
@@ -768,6 +788,7 @@ export function useProblemEdit() {
 		addSampleInput,
 		removeSampleInput,
 		handleTestcaseAdd,
+		handleTestcaseAddManual,
 		handleTestcaseRemove,
 		handleTestcaseChange,
 		handleParsedTestcaseRemove,

--- a/src/pages/TutorPage/Problems/ProblemManagement/components/ProblemManagementView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemManagement/components/ProblemManagementView.tsx
@@ -147,6 +147,18 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 					</S.SearchBox>
 					<S.FilterGroup>
 						<S.FilterSelect
+							id="filter-original"
+							value={d.filterOriginalOnly}
+							onChange={(e) =>
+								d.setFilterOriginalOnly(e.target.value as "ALL" | "ORIGINAL")
+							}
+						>
+							<option value="ALL">전체 문제</option>
+							<option value="ORIGINAL">원본(오리지널)만</option>
+						</S.FilterSelect>
+					</S.FilterGroup>
+					<S.FilterGroup>
+						<S.FilterSelect
 							id="filter-usage"
 							value={d.filterUsageStatus}
 							onChange={(e) => {
@@ -603,7 +615,7 @@ export default function ProblemManagementView(d: ProblemManagementHookReturn) {
 										type="text"
 										value={d.copyTitle}
 										onChange={(e) => d.setCopyTitle(e.target.value)}
-										placeholder="복사본 문제 제목을 입력하세요"
+										placeholder="문제 제목을 입력하세요"
 										disabled={d.isCopying}
 									/>
 								</S.FormGroup>

--- a/src/pages/TutorPage/Problems/ProblemManagement/hooks/useProblemManagement.ts
+++ b/src/pages/TutorPage/Problems/ProblemManagement/hooks/useProblemManagement.ts
@@ -1,14 +1,36 @@
-import { useState, useEffect, useCallback } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import APIService from "../../../../../services/APIService";
 import type { Problem, Section, Assignment, ProblemUsage } from "../types";
 
+const PARAM_ORIGINAL = "originalOnly";
+const PARAM_SEARCH = "search";
+const PARAM_USAGE = "usage";
+const PARAM_DIFFICULTY = "difficulty";
+const PARAM_TAG = "tag";
+const PARAM_COURSE = "course";
+const PARAM_ASSIGNMENT = "assignment";
+
+function readFiltersFromParams(searchParams: URLSearchParams) {
+	return {
+		originalOnly: (searchParams.get(PARAM_ORIGINAL) === "ORIGINAL" ? "ORIGINAL" : "ALL") as "ALL" | "ORIGINAL",
+		search: searchParams.get(PARAM_SEARCH) ?? "",
+		usage: searchParams.get(PARAM_USAGE) ?? "ALL",
+		difficulty: searchParams.get(PARAM_DIFFICULTY) ?? "ALL",
+		tag: searchParams.get(PARAM_TAG) ?? "ALL",
+		course: searchParams.get(PARAM_COURSE) ?? "ALL",
+		assignment: searchParams.get(PARAM_ASSIGNMENT) ?? "ALL",
+	};
+}
+
 export function useProblemManagement() {
 	const navigate = useNavigate();
+	const [searchParams, setSearchParams] = useSearchParams();
+	const initial = readFiltersFromParams(searchParams);
 
 	const [problems, setProblems] = useState<Problem[]>([]);
 	const [loading, setLoading] = useState(true);
-	const [searchTerm, setSearchTerm] = useState("");
+	const [searchTerm, setSearchTerm] = useState(initial.search);
 	const [selectedProblem, setSelectedProblem] = useState<Problem | null>(null);
 	const [showProblemModal, setShowProblemModal] = useState(false);
 	const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -28,11 +50,12 @@ export function useProblemManagement() {
 	});
 	const [loadingUsage, setLoadingUsage] = useState(false);
 	const [problemForUsage, setProblemForUsage] = useState<Problem | null>(null);
-	const [filterUsageStatus, setFilterUsageStatus] = useState("ALL");
-	const [filterDifficulty, setFilterDifficulty] = useState("ALL");
-	const [filterCourse, setFilterCourse] = useState("ALL");
-	const [filterAssignment, setFilterAssignment] = useState("ALL");
-	const [filterTag, setFilterTag] = useState("ALL");
+	const [filterUsageStatus, setFilterUsageStatus] = useState(initial.usage);
+	const [filterDifficulty, setFilterDifficulty] = useState(initial.difficulty);
+	const [filterCourse, setFilterCourse] = useState(initial.course);
+	const [filterAssignment, setFilterAssignment] = useState(initial.assignment);
+	const [filterTag, setFilterTag] = useState(initial.tag);
+	const [filterOriginalOnly, setFilterOriginalOnly] = useState<"ALL" | "ORIGINAL">(initial.originalOnly);
 	const [sections, setSections] = useState<Section[]>([]);
 	const [assignments, setAssignments] = useState<Assignment[]>([]);
 	const [problemUsageMap, setProblemUsageMap] = useState<
@@ -93,6 +116,45 @@ export function useProblemManagement() {
 			setLoading(false);
 		}
 	}, []);
+
+	// URL에 필터/검색 상태 반영 (뒤로가기 시 복원되도록)
+	const isFirstMount = useRef(true);
+	useEffect(() => {
+		if (isFirstMount.current) {
+			isFirstMount.current = false;
+			return;
+		}
+		setSearchParams(
+			(prev) => {
+				const next = new URLSearchParams(prev);
+				if (filterOriginalOnly === "ORIGINAL") next.set(PARAM_ORIGINAL, "ORIGINAL");
+				else next.delete(PARAM_ORIGINAL);
+				if (searchTerm.trim()) next.set(PARAM_SEARCH, searchTerm.trim());
+				else next.delete(PARAM_SEARCH);
+				if (filterUsageStatus !== "ALL") next.set(PARAM_USAGE, filterUsageStatus);
+				else next.delete(PARAM_USAGE);
+				if (filterDifficulty !== "ALL") next.set(PARAM_DIFFICULTY, filterDifficulty);
+				else next.delete(PARAM_DIFFICULTY);
+				if (filterTag !== "ALL") next.set(PARAM_TAG, filterTag);
+				else next.delete(PARAM_TAG);
+				if (filterCourse !== "ALL") next.set(PARAM_COURSE, filterCourse);
+				else next.delete(PARAM_COURSE);
+				if (filterAssignment !== "ALL") next.set(PARAM_ASSIGNMENT, filterAssignment);
+				else next.delete(PARAM_ASSIGNMENT);
+				return next;
+			},
+			{ replace: true },
+		);
+	}, [
+		filterOriginalOnly,
+		searchTerm,
+		filterUsageStatus,
+		filterDifficulty,
+		filterTag,
+		filterCourse,
+		filterAssignment,
+		setSearchParams,
+	]);
 
 	const fetchSections = useCallback(async () => {
 		try {
@@ -208,6 +270,8 @@ export function useProblemManagement() {
 		const matchesSearch = problem.title
 			?.toLowerCase()
 			.includes(searchTerm.toLowerCase());
+		const matchesOriginal =
+			filterOriginalOnly === "ALL" || (problem.title ?? "").endsWith("_오리지널");
 		let matchesUsage = true;
 		if (filterUsageStatus === "USED") {
 			matchesUsage = problem.isUsed === true;
@@ -242,6 +306,7 @@ export function useProblemManagement() {
 		}
 		return (
 			matchesSearch &&
+			matchesOriginal &&
 			matchesUsage &&
 			matchesDifficulty &&
 			matchesTag &&
@@ -299,7 +364,8 @@ export function useProblemManagement() {
 
 	const handleCopyClick = useCallback((problem: Problem) => {
 		setProblemToCopy(problem);
-		setCopyTitle(`${problem.title} (복사본)`);
+		const baseTitle = problem.title?.replace(/_오리지널$/, "").trim() || problem.title || "";
+		setCopyTitle(baseTitle || "제목 없음");
 		setShowCopyModal(true);
 	}, []);
 
@@ -533,6 +599,8 @@ export function useProblemManagement() {
 		setFilterAssignment,
 		filterTag,
 		setFilterTag,
+		filterOriginalOnly,
+		setFilterOriginalOnly,
 		sections,
 		assignments,
 		problemUsageMap,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #144 

## 📝작업 내용
# Frontend 변경 사항 (Git Issue용)

## 1. 대시보드 · 과제/공지 활성/비활성 확인 팝업
- **대시보드** (`/tutor`): 수업(분반) 활성/비활성 토글 클릭 시 `window.confirm`으로 "이 수업을 활성화/비활성화하시겠습니까?" 확인 후 처리
- **과제 관리**: 과제별 활성/비활성, 전체 일괄 토글 시 확인 메시지 후 API 호출
- **공지 관리**: 공지별 활성/비활성, 전체 일괄 토글 시 확인 메시지 후 API 호출

## 2. 성적 페이지 제출 시간 · 지각 표기
- **성적 페이지** (`/tutor/grades/section/:sectionId`): 제출 상태 아이콘(✓ 제시간 제출, ⚠ 지각 제출)에 마우스 오버 시 **제출 시각** 툴팁 표시 (`submittedAt` → `toLocaleString("ko-KR")`)
- 아이콘을 `title`이 있는 `<span>`으로 감싸 브라우저별 툴팁 동작 보장
- `submitted_at`(스네이크 케이스) 응답도 사용하도록 `getSubmittedAt` 처리

## 3. 과제 페이지(학생) 제출 시간 · 지각 표기
- **과제 페이지** (`/sections/:sectionId/course-assignments`): 본인 제출 문제에 **제출 시각** 표시, **지각 제출** 시 "N일 N시간 N분 늦음" 문구 표시
- 미제출에는 제출 시간/늦음 미표시
- `formatSubmissionTime`, `formatMinutesLate` 유틸 추가
- API `submittedAt`, `minutesLate` 연동

## 4. 과제 추가 시 문제 목록 필터
- **과제 관리 → 문제 추가** 모달: "이미 이 과제에 포함된 문제" 제외 필터 제거 → **전체 가용 문제**를 검색어만으로 필터링해 표시
- 과제마다 개수 차이 없이 동일한 전체 목록 노출

## 5. 문제 관리 페이지
- **원본(오리지널)만** 필터 추가: 제목이 `_오리지널`로 끝나는 문제만 보기
- **필터 상태 URL 유지**: 검색어, 원본만, 사용 여부, 난이도, 태그, 수업/과제 등 필터를 쿼리 파라미터로 저장. 수정 페이지 갔다가 **뒤로 가기** 해도 필터 복원
- 문제 **복사** 모달: 기본 제목을 `_오리지널` 제거한 값으로 설정, placeholder "문제 제목을 입력하세요"로 변경

## 6. 문제 생성 · 수정 시 테스트케이스 직접 입력
- **문제 수정** (`/tutor/problems/:id/edit`):
  - 테스트케이스 **직접 추가** 버튼 추가 (파일 추가와 별도)
  - 각 테스트케이스 **이름 · 입력 · 출력** 직접 편집 (textarea), 타입(샘플/비밀) 선택
- **문제 생성** (`/tutor/problems/create`):
  - **+ 테스트케이스 직접 추가** 버튼 및 직접 추가 목록 UI
  - 이름, 타입, 입력, 출력 입력/수정 가능
  - 제출 시 파일·ZIP 파싱·직접 추가 테스트케이스 병합 후 전송
  - 유효성 검사에 직접 추가 테스트케이스 반영

## 7. 기타
- 문제 추가 모달에 "전체 N개 중 이미 이 과제에 포함된 문제 제외" 문구 제거 (전체 목록 노출로 변경했으므로)
