### PR TITLE
feat/issue-154/superadminpage

### DIFF
--- a/src/pages/AdminPage/styleddiv.js
+++ b/src/pages/AdminPage/styleddiv.js
@@ -1,5 +1,0 @@
-import styled from 'styled-components';
-
-// AdminPage 공통 스타일
-// 각 페이지의 CSS를 점진적으로 이 파일로 이동합니다
-

--- a/src/pages/Auth/IndexPage/components/IndexPageView.tsx
+++ b/src/pages/Auth/IndexPage/components/IndexPageView.tsx
@@ -25,9 +25,9 @@ export default function IndexPageView(d: IndexPageHookReturn) {
 						<S.HeroContent>
 							<S.HeroTitle>H-CodeLab</S.HeroTitle>
 							<S.HeroDescription>
-								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut sit
-								amet risus nisi, integer firibus faucibus pours. Maecenas
-								pharetra eropuest
+								오늘의 한 줄 코드가 내일의 실력이 됩니다. 작은 문제 하나씩 풀며,
+								분명한 성장의 흔적을 만들어보세요. H-CodeLab에서 꾸준함을
+								실력으로 바꾸세요.
 							</S.HeroDescription>
 						</S.HeroContent>
 						<S.HeroButton onClick={d.handleGoToClassroom}>

--- a/src/pages/Auth/IndexPage/styles.ts
+++ b/src/pages/Auth/IndexPage/styles.ts
@@ -78,6 +78,7 @@ export const HeroTitle = styled.h1`
 export const HeroDescription = styled.p`
   font-size: 16px;
   color: white;
+  font-weight: 900;
   line-height: 1.6;
   margin: 0;
   opacity: 0.95;

--- a/src/pages/SuperAdminPage/SuperAdminCourseManagement/components/SuperAdminCourseManagementView.tsx
+++ b/src/pages/SuperAdminPage/SuperAdminCourseManagement/components/SuperAdminCourseManagementView.tsx
@@ -20,41 +20,121 @@ export default function SuperAdminCourseManagementView(
 			<Header onUserNameClick={() => {}} />
 			<S.Container>
 				<S.Header>
-					<S.Title>강좌 관리</S.Title>
+					<S.Title>분반/과제 관리</S.Title>
 				</S.Header>
 
 				<S.CoursesGrid>
-					{d.courses.map((course) => (
-						<S.CourseCard key={course.id}>
-							<S.CourseTitle>{course.title}</S.CourseTitle>
-							{course.description && (
-								<S.CourseInfo>{course.description}</S.CourseInfo>
-							)}
+					{d.sections.map((section) => (
+						<S.CourseCard key={section.sectionId}>
+							<S.CourseTitle>
+								{section.courseTitle} - {section.sectionNumber}분반
+							</S.CourseTitle>
 							<S.SectionsList>
-								{course.semester && (
+								{section.semester && (
 									<S.SectionItem>
 										<span>학기</span>
 										<span>
-											{course.year}-{course.semester}
+											{section.year}-{section.semester}
 										</span>
 									</S.SectionItem>
 								)}
-								{course.instructorName && (
+								{section.instructorName && (
 									<S.SectionItem>
 										<span>담당 강사</span>
-										<span>{course.instructorName}</span>
+										<span>{section.instructorName}</span>
 									</S.SectionItem>
 								)}
 								<S.SectionItem>
-									<span>분반 수</span>
-									<span>{course.sectionCount || 0}개</span>
+									<span>학생 수</span>
+									<span>{section.studentCount || 0}명</span>
+								</S.SectionItem>
+								<S.SectionItem>
+									<span>과제 수</span>
+									<span>{section.assignmentCount || 0}개</span>
 								</S.SectionItem>
 							</S.SectionsList>
+							<button
+								type="button"
+								onClick={() => d.toggleSectionDetail(section.sectionId)}
+								style={{
+									marginTop: "0.75rem",
+									padding: "0.5rem 0.75rem",
+									borderRadius: "8px",
+									border: "1px solid #d1d5db",
+									background: "white",
+									cursor: "pointer",
+								}}
+							>
+								{d.expandedSectionId === section.sectionId
+									? "상세 닫기"
+									: "학생/과제 보기"}
+							</button>
+
+							{d.expandedSectionId === section.sectionId && (
+								<div
+									style={{
+										marginTop: "1rem",
+										maxHeight: "320px",
+										overflowY: "auto",
+										paddingRight: "0.25rem",
+									}}
+								>
+									<h4 style={{ marginBottom: "0.5rem" }}>학생 목록</h4>
+									<ul style={{ margin: 0, paddingLeft: "1rem" }}>
+										{(d.studentsBySection[section.sectionId] || []).map(
+											(student) => (
+												<li key={student.userId}>
+													{student.name} ({student.email})
+												</li>
+											),
+										)}
+									</ul>
+
+									<h4 style={{ margin: "1rem 0 0.5rem" }}>
+										과제/문제 목록
+									</h4>
+									<ul style={{ margin: 0, paddingLeft: "1rem" }}>
+										{(d.assignmentsBySection[section.sectionId] || []).map(
+											(assignment) => (
+												<li key={assignment.id}>
+													<button
+														type="button"
+														onClick={() =>
+															d.loadAssignmentProblems(
+																section.sectionId,
+																assignment.id,
+															)
+														}
+														style={{
+															border: "none",
+															background: "transparent",
+															padding: 0,
+															cursor: "pointer",
+															textDecoration: "underline",
+														}}
+													>
+														{assignment.title}
+													</button>
+													<ul style={{ marginTop: "0.4rem" }}>
+														{(
+															d.problemsByAssignment[
+																`${section.sectionId}-${assignment.id}`
+															] || []
+														).map((problem) => (
+															<li key={problem.id}>{problem.title}</li>
+														))}
+													</ul>
+												</li>
+											),
+										)}
+									</ul>
+								</div>
+							)}
 						</S.CourseCard>
 					))}
 				</S.CoursesGrid>
 
-				{d.courses.length === 0 && (
+				{d.sections.length === 0 && (
 					<div
 						style={{
 							textAlign: "center",
@@ -63,7 +143,7 @@ export default function SuperAdminCourseManagementView(
 							borderRadius: "8px",
 						}}
 					>
-						<p style={{ color: "#9ca3af" }}>등록된 강좌가 없습니다.</p>
+						<p style={{ color: "#9ca3af" }}>등록된 분반이 없습니다.</p>
 					</div>
 				)}
 			</S.Container>

--- a/src/pages/SuperAdminPage/SuperAdminCourseManagement/hooks/useSuperAdminCourseManagement.ts
+++ b/src/pages/SuperAdminPage/SuperAdminCourseManagement/hooks/useSuperAdminCourseManagement.ts
@@ -1,28 +1,95 @@
 import { useState, useEffect, useCallback } from "react";
 import APIService from "../../../../services/APIService";
-import type { Course } from "../types";
+import type {
+	AssignmentProblem,
+	Section,
+	SectionAssignment,
+	SectionStudent,
+} from "../types";
 
 export function useSuperAdminCourseManagement() {
-	const [courses, setCourses] = useState<Course[]>([]);
+	const [sections, setSections] = useState<Section[]>([]);
 	const [loading, setLoading] = useState(true);
+	const [expandedSectionId, setExpandedSectionId] = useState<number | null>(null);
+	const [studentsBySection, setStudentsBySection] = useState<
+		Record<number, SectionStudent[]>
+	>({});
+	const [assignmentsBySection, setAssignmentsBySection] = useState<
+		Record<number, SectionAssignment[]>
+	>({});
+	const [problemsByAssignment, setProblemsByAssignment] = useState<
+		Record<string, AssignmentProblem[]>
+	>({});
 
-	const fetchCourses = useCallback(async () => {
+	const fetchSections = useCallback(async () => {
 		try {
 			setLoading(true);
-			const response = await APIService.getAllCourses();
-			setCourses(response?.data || response || []);
+			const response = await APIService.getAllSectionsForSuperAdmin();
+			setSections(response?.data || []);
 		} catch (error) {
-			console.error("강좌 조회 실패:", error);
+			console.error("분반 조회 실패:", error);
 		} finally {
 			setLoading(false);
 		}
 	}, []);
 
 	useEffect(() => {
-		fetchCourses();
-	}, [fetchCourses]);
+		fetchSections();
+	}, [fetchSections]);
 
-	return { courses, loading };
+	const toggleSectionDetail = useCallback(async (sectionId: number) => {
+		if (expandedSectionId === sectionId) {
+			setExpandedSectionId(null);
+			return;
+		}
+
+		setExpandedSectionId(sectionId);
+
+		try {
+			const [studentsResponse, assignmentsResponse] = await Promise.all([
+				APIService.getSectionStudents(sectionId),
+				APIService.getAssignmentsBySection(sectionId),
+			]);
+
+			const students = studentsResponse?.data || [];
+			const assignments = assignmentsResponse?.data || assignmentsResponse || [];
+
+			setStudentsBySection((prev) => ({ ...prev, [sectionId]: students }));
+			setAssignmentsBySection((prev) => ({ ...prev, [sectionId]: assignments }));
+		} catch (error) {
+			console.error("분반 상세 조회 실패:", error);
+		}
+	}, [expandedSectionId]);
+
+	const loadAssignmentProblems = useCallback(
+		async (sectionId: number, assignmentId: number) => {
+			const key = `${sectionId}-${assignmentId}`;
+			if (problemsByAssignment[key]) return;
+
+			try {
+				const response = await APIService.getAssignmentProblems(
+					sectionId,
+					assignmentId,
+				);
+				const problems = response?.data || response || [];
+				setProblemsByAssignment((prev) => ({ ...prev, [key]: problems }));
+			} catch (error) {
+				console.error("과제 문제 조회 실패:", error);
+			}
+		},
+		[problemsByAssignment],
+	);
+
+	return {
+		sections,
+		loading,
+		expandedSectionId,
+		studentsBySection,
+		assignmentsBySection,
+		problemsByAssignment,
+		toggleSectionDetail,
+		loadAssignmentProblems,
+	};
 }
 
 export type SuperAdminCourseManagementHookReturn = ReturnType<

--- a/src/pages/SuperAdminPage/SuperAdminCourseManagement/types.ts
+++ b/src/pages/SuperAdminPage/SuperAdminCourseManagement/types.ts
@@ -1,9 +1,32 @@
-export interface Course {
+export interface Section {
+	sectionId: number;
+	courseId: number;
+	courseTitle: string;
+	sectionNumber: number;
+	instructorName?: string;
+	studentCount?: number;
+	assignmentCount?: number;
+	noticeCount?: number;
+	year?: number;
+	semester?: string;
+	active?: boolean;
+}
+
+export interface SectionStudent {
+	userId: number;
+	name: string;
+	email: string;
+	studentId?: string;
+	role?: string;
+}
+
+export interface SectionAssignment {
 	id: number;
 	title: string;
-	description?: string;
-	semester?: string;
-	year?: number;
-	instructorName?: string;
-	sectionCount?: number;
+	assignmentNumber?: string;
+}
+
+export interface AssignmentProblem {
+	id: number;
+	title: string;
 }

--- a/src/pages/SuperAdminPage/SuperAdminDashboard/components/SuperAdminDashboardView.tsx
+++ b/src/pages/SuperAdminPage/SuperAdminDashboard/components/SuperAdminDashboardView.tsx
@@ -7,6 +7,7 @@ import {
 	FaUniversity,
 	FaList,
 } from "react-icons/fa";
+import { Link } from "react-router-dom";
 import Header from "../../../../components/Layout/Header";
 import LoadingSpinner from "../../../../components/UI/LoadingSpinner";
 import type { SuperAdminDashboardHookReturn } from "../hooks/useSuperAdminDashboard";
@@ -70,7 +71,7 @@ export default function SuperAdminDashboardView(
 			<S.Container>
 				<S.Title>시스템 관리자 대시보드</S.Title>
 				<S.StatsGrid>
-					<S.StatCard>
+					<S.StatCard as={Link} to="/super-admin/users">
 						<S.StatIcon>
 							<FaUsers />
 						</S.StatIcon>
@@ -79,7 +80,7 @@ export default function SuperAdminDashboardView(
 							<S.StatValue>{d.stats.totalUsers.toLocaleString()}</S.StatValue>
 						</S.StatContent>
 					</S.StatCard>
-					<S.StatCard>
+					<S.StatCard as={Link} to="/super-admin/courses">
 						<S.StatIcon>
 							<FaUniversity />
 						</S.StatIcon>
@@ -90,7 +91,7 @@ export default function SuperAdminDashboardView(
 							</S.StatValue>
 						</S.StatContent>
 					</S.StatCard>
-					<S.StatCard>
+					<S.StatCard as={Link} to="/super-admin/courses">
 						<S.StatIcon>
 							<FaFileAlt />
 						</S.StatIcon>
@@ -101,7 +102,7 @@ export default function SuperAdminDashboardView(
 							</S.StatValue>
 						</S.StatContent>
 					</S.StatCard>
-					<S.StatCard>
+					<S.StatCard as={Link} to="/super-admin/problems">
 						<S.StatIcon>
 							<FaCode />
 						</S.StatIcon>
@@ -112,7 +113,7 @@ export default function SuperAdminDashboardView(
 							</S.StatValue>
 						</S.StatContent>
 					</S.StatCard>
-					<S.StatCard>
+					<S.StatCard as={Link} to="/super-admin/system-notices">
 						<S.StatIcon>
 							<FaBullhorn />
 						</S.StatIcon>
@@ -123,7 +124,7 @@ export default function SuperAdminDashboardView(
 							</S.StatValue>
 						</S.StatContent>
 					</S.StatCard>
-					<S.StatCard>
+					<S.StatCard as={Link} to="/super-admin/system-guides">
 						<S.StatIcon>
 							<FaBookOpen />
 						</S.StatIcon>
@@ -146,8 +147,8 @@ export default function SuperAdminDashboardView(
 					빠른 작업
 				</h2>
 				<S.ActionsGrid>
-					{quickActions.map((action, index) => (
-						<S.ActionCard key={index} onClick={() => d.navigate(action.path)}>
+					{quickActions.map((action) => (
+						<S.ActionCard as={Link} to={action.path} key={action.path}>
 							<S.ActionIcon>{action.icon}</S.ActionIcon>
 							<S.ActionTitle>{action.title}</S.ActionTitle>
 							<S.ActionDescription>{action.description}</S.ActionDescription>

--- a/src/pages/SuperAdminPage/SuperAdminSubmissionManagement/components/SuperAdminSubmissionManagementView.tsx
+++ b/src/pages/SuperAdminPage/SuperAdminSubmissionManagement/components/SuperAdminSubmissionManagementView.tsx
@@ -36,6 +36,11 @@ export default function SuperAdminSubmissionManagementView(
 						}}
 					>
 						<option value="ALL">전체 결과</option>
+						<option value="AC">AC</option>
+						<option value="WA">WA</option>
+						<option value="RE">RE</option>
+						<option value="TLE">TLE</option>
+						<option value="CE">CE</option>
 						<option value="ACCEPTED">정답</option>
 						<option value="WRONG_ANSWER">오답</option>
 						<option value="RUNTIME_ERROR">런타임 에러</option>
@@ -70,7 +75,7 @@ export default function SuperAdminSubmissionManagementView(
 												fontSize: "0.75rem",
 												fontWeight: 600,
 												backgroundColor:
-													d.getResultColor(submission.result) + "20",
+													`${d.getResultColor(submission.result)}20`,
 												color: d.getResultColor(submission.result),
 											}}
 										>

--- a/src/pages/SuperAdminPage/SuperAdminSubmissionManagement/hooks/useSuperAdminSubmissionManagement.ts
+++ b/src/pages/SuperAdminPage/SuperAdminSubmissionManagement/hooks/useSuperAdminSubmissionManagement.ts
@@ -11,7 +11,7 @@ export function useSuperAdminSubmissionManagement() {
 		try {
 			setLoading(true);
 			const response = await APIService.getAllSubmissionsForSuperAdmin();
-			setSubmissions(response?.data?.content || response || []);
+			setSubmissions(response?.data || []);
 		} catch (error) {
 			console.error("제출 내역 조회 실패:", error);
 		} finally {
@@ -25,6 +25,11 @@ export function useSuperAdminSubmissionManagement() {
 
 	const getResultColor = useCallback((result: string): string => {
 		const colors: Record<string, string> = {
+			AC: "#10b981",
+			WA: "#ef4444",
+			RE: "#f59e0b",
+			TLE: "#8b5cf6",
+			CE: "#6b7280",
 			ACCEPTED: "#10b981",
 			WRONG_ANSWER: "#ef4444",
 			RUNTIME_ERROR: "#f59e0b",

--- a/src/pages/SuperAdminPage/SuperAdminSubmissionManagement/types.ts
+++ b/src/pages/SuperAdminPage/SuperAdminSubmissionManagement/types.ts
@@ -11,6 +11,11 @@ export interface Submission {
 
 export type ResultFilter =
 	| "ALL"
+	| "AC"
+	| "WA"
+	| "RE"
+	| "TLE"
+	| "CE"
 	| "ACCEPTED"
 	| "WRONG_ANSWER"
 	| "RUNTIME_ERROR"

--- a/src/pages/SuperAdminPage/SuperAdminUserManagement/components/SuperAdminUserManagementView.tsx
+++ b/src/pages/SuperAdminPage/SuperAdminUserManagement/components/SuperAdminUserManagementView.tsx
@@ -44,8 +44,7 @@ export default function SuperAdminUserManagementView(
 						}}
 					>
 						<option value="ALL">전체 역할</option>
-						<option value="STUDENT">학생</option>
-						<option value="INSTRUCTOR">강사</option>
+						<option value="USER">학생</option>
 						<option value="ADMIN">관리자</option>
 						<option value="SUPER_ADMIN">시스템 관리자</option>
 					</select>
@@ -65,7 +64,7 @@ export default function SuperAdminUserManagementView(
 							{d.filteredUsers.map((u) => (
 								<tr key={u.id}>
 									<S.Td>{u.name}</S.Td>
-									<S.Td>{u.email}</S.Td>
+									<S.Td>{u.email || "-"}</S.Td>
 									<S.Td>{u.studentId || "-"}</S.Td>
 									<S.Td>
 										<span
@@ -82,7 +81,9 @@ export default function SuperAdminUserManagementView(
 										</span>
 									</S.Td>
 									<S.Td>
-										{new Date(u.createdAt).toLocaleDateString("ko-KR")}
+										{u.createdAt
+											? new Date(u.createdAt).toLocaleDateString("ko-KR")
+											: "-"}
 									</S.Td>
 								</tr>
 							))}

--- a/src/pages/SuperAdminPage/SuperAdminUserManagement/hooks/useSuperAdminUserManagement.ts
+++ b/src/pages/SuperAdminPage/SuperAdminUserManagement/hooks/useSuperAdminUserManagement.ts
@@ -11,8 +11,8 @@ export function useSuperAdminUserManagement() {
 	const fetchUsers = useCallback(async () => {
 		try {
 			setLoading(true);
-			const response = await APIService.getAllUsers();
-			setUsers(response?.data || response || []);
+			const response = await APIService.getAllUsersForSuperAdmin();
+			setUsers(response?.data || []);
 		} catch (error) {
 			console.error("사용자 조회 실패:", error);
 		} finally {
@@ -26,8 +26,7 @@ export function useSuperAdminUserManagement() {
 
 	const getRoleLabel = useCallback((role: string): string => {
 		const labels: Record<string, string> = {
-			STUDENT: "학생",
-			INSTRUCTOR: "강사",
+			USER: "학생",
 			ADMIN: "관리자",
 			SUPER_ADMIN: "시스템 관리자",
 		};
@@ -37,10 +36,11 @@ export function useSuperAdminUserManagement() {
 	const filteredUsers = useMemo(
 		() =>
 			users.filter((u) => {
+				const lowerSearch = searchTerm.toLowerCase();
 				const matchesSearch =
-					u.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-					u.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
-					(u.studentId && u.studentId.includes(searchTerm));
+					u.name.toLowerCase().includes(lowerSearch) ||
+					(u.email?.toLowerCase().includes(lowerSearch) ?? false) ||
+					u.studentId?.includes(searchTerm);
 				const matchesRole = roleFilter === "ALL" || u.role === roleFilter;
 				return matchesSearch && matchesRole;
 			}),

--- a/src/pages/SuperAdminPage/SuperAdminUserManagement/types.ts
+++ b/src/pages/SuperAdminPage/SuperAdminUserManagement/types.ts
@@ -1,15 +1,10 @@
 export interface User {
 	id: number;
-	email: string;
+	email?: string;
 	name: string;
 	studentId?: string;
 	role: string;
-	createdAt: string;
+	createdAt?: string;
 }
 
-export type RoleFilter =
-	| "ALL"
-	| "STUDENT"
-	| "INSTRUCTOR"
-	| "ADMIN"
-	| "SUPER_ADMIN";
+export type RoleFilter = "ALL" | "USER" | "ADMIN" | "SUPER_ADMIN";

--- a/src/pages/TutorPage/Dashboard/styles.ts
+++ b/src/pages/TutorPage/Dashboard/styles.ts
@@ -1293,6 +1293,7 @@ export const CoursesGrid = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 1.5rem;
   margin-bottom: 2rem;
+  align-items: start;
 
   @media (max-width: 1024px) {
     grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #154 

## 📝작업 내용
## 개요
- **이슈**: #154 (Super Admin 관련 FE 작업)
- **브랜치**: `154-feat-superadmin`
- **대표 커밋**: `cbbd6ec` — `feat/issue-154/superadminpage`
- **저장소**: `Handongjudge_FE` (프론트엔드)

## 목적
시스템 관리자(Super Admin) 화면에서 **분반·수강생·과제·문제**를 한눈에 보고 펼쳐서 확인할 수 있도록 강좌 관리 UX를 보강하고, 랜딩(인덱스) 카피를 서비스명에 맞게 정리한다.

## 주요 변경 사항

### 1. Super Admin — 분반/과제 관리 (`/super-admin/courses`)
- `APIService.getAllSectionsForSuperAdmin()`으로 **전체 분반 목록** 조회.
- 카드 단위로 **강좌명·분반 번호·학기·담당 강사·학생 수·과제 수** 표시.
- **「학생/과제 보기」** 토글로 상세 영역 확장/축소.
- 확장 시 `getSectionStudents`, `getAssignmentsBySection`으로 **해당 분반 학생 목록·과제 목록** 병렬 로딩.
- 과제별로 **문제 목록**은 `getAssignmentProblems`로 **지연 로딩**(이미 불러온 키는 재요청 생략).
- 타입 정의 보강: `Section`, `SectionStudent`, `SectionAssignment`, `AssignmentProblem` 등.

### 2. Super Admin — 대시보드 퀵 액션
- 메뉴 설명/라벨 정리 (예: 제출 내역 등 경로·문구 일관성).

### 3. Super Admin — 사용자 / 제출 내역
- 조회·필터 로직 및 타입 소폭 정리 (역할 라벨, 제출 결과 필터·색상 매핑 등).

### 4. 랜딩(인덱스) 페이지
- 히어로 타이틀·설명을 **H-CodeLab** 브랜딩 및 안내 문구에 맞게 수정.
- 스타일(`styles.ts`) 소폭 조정.

### 5. 기타
- `src/pages/AdminPage/styleddiv.js` **삭제** (미사용 정리).
- `TutorPage/Dashboard/styles.ts` **1라인** 수준 스타일 보정.

## 변경 파일 (이 커밋 기준, 14 files)
| 구분 | 경로 |
|------|------|
| 삭제 | `src/pages/AdminPage/styleddiv.js` |
| 인덱스 | `Auth/IndexPage/components/IndexPageView.tsx`, `Auth/IndexPage/styles.ts` |
| Super Admin | `SuperAdminCourseManagement/*`, `SuperAdminDashboard/*`, `SuperAdminSubmissionManagement/*`, `SuperAdminUserManagement/*` |
| 공통 스타일 | `TutorPage/Dashboard/styles.ts` (강좌 관리 화면에서 재사용) |

## 연동·배포 시 참고
- 분반/학생/과제/문제 API가 백엔드에서 Super Admin 권한과 맞게 동작해야 함.
- 백엔드 쪽은 별도 브랜치(예: `135-featsuperadmin`)와 이슈 번호를 맞출지 팀 규칙에 따라 정리 권장.

## 수동 테스트 체크리스트
- [ ] Super Admin으로 로그인 후 **강좌 관리** 진입 시 분반 목록 로딩
- [ ] 카드에서 **학생/과제 보기** → 학생·과제 표시
- [ ] 과제 클릭 시 **문제 목록** 지연 로딩
- [ ] 사용자 관리·제출 내역 페이지 기존 동작(필터 등) 회귀 없음
- [ ] 비로그인 랜딩(인덱스) 문구·레이아웃 확인