### PR TITLE
feat: add quiz solve session takeover UX and memory token flow

### DIFF
--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/components/CodingQuizSolveView.tsx
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/components/CodingQuizSolveView.tsx
@@ -78,6 +78,51 @@ export default function CodingQuizSolveView(d: UseCodingQuizSolveReturn) {
 	return (
 		<DndProvider backend={HTML5Backend}>
 			<S.PageWrapper className={`problem-solve-page ${d.theme}`} $theme={d.theme}>
+				{/* 다른 환경에서 이미 시험 진행 중 - 강제 인계 확인 모달 */}
+				{d.examSessionConflict && (
+					<S.OverlayModal>
+						<S.OverlayModalBox>
+							<S.OverlayModalTitle>이미 다른 환경에서 시험 진행 중</S.OverlayModalTitle>
+							<S.OverlayModalDesc>
+								현재 다른 기기 또는 브라우저에서 이 시험이 진행 중입니다.
+								<br />
+								여기서 계속 진행하면 기존 세션이 종료됩니다.
+							</S.OverlayModalDesc>
+							<S.OverlayModalButtons>
+								<S.OverlayModalConfirm type="button" onClick={d.handleExamSessionTakeover}>
+									여기서 계속하기
+								</S.OverlayModalConfirm>
+								<S.OverlayModalCancel
+									type="button"
+									onClick={() => navigate(`/sections/${d.sectionId}/coding-quiz`)}
+								>
+									돌아가기
+								</S.OverlayModalCancel>
+							</S.OverlayModalButtons>
+						</S.OverlayModalBox>
+					</S.OverlayModal>
+				)}
+				{/* 다른 환경에서 세션을 인계해간 경우 */}
+				{d.examSessionTakenOver && (
+					<S.OverlayModal>
+						<S.OverlayModalBox>
+							<S.OverlayModalTitle>세션이 종료되었습니다</S.OverlayModalTitle>
+							<S.OverlayModalDesc>
+								다른 기기 또는 브라우저에서 동일한 계정으로 시험에 접속했습니다.
+								<br />
+								이 페이지에서는 더 이상 시험을 진행할 수 없습니다.
+							</S.OverlayModalDesc>
+							<S.OverlayModalButtons>
+								<S.OverlayModalCancel
+									type="button"
+									onClick={() => navigate(`/sections/${d.sectionId}/coding-quiz`)}
+								>
+									목록으로 돌아가기
+								</S.OverlayModalCancel>
+							</S.OverlayModalButtons>
+						</S.OverlayModalBox>
+					</S.OverlayModal>
+				)}
 				{d.showSaveModal && (
 					<S.SaveModal>
 						<S.SaveModalContent>

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/hooks/useCodingQuizSolve.ts
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/hooks/useCodingQuizSolve.ts
@@ -70,6 +70,15 @@ export function useCodingQuizSolve() {
 	const [isProblemModalOpen, setIsProblemModalOpen] = useState(false);
 	const [showSaveModal, setShowSaveModal] = useState(false);
 
+	// 시험 중복 접속 방지용 (학생 전용)
+	const [examClientSessionId] = useState<string>(() =>
+		typeof crypto !== "undefined" && crypto.randomUUID
+			? crypto.randomUUID()
+			: Math.random().toString(36).slice(2),
+	);
+	const [examSessionConflict, setExamSessionConflict] = useState(false);
+	const [examSessionTakenOver, setExamSessionTakenOver] = useState(false);
+
 	// 사용자 역할 확인
 	useEffect(() => {
 		const fetchUserRole = async () => {
@@ -195,6 +204,64 @@ export function useCodingQuizSolve() {
 		};
 		initializeSession();
 	}, []);
+
+	// 시험 페이지 진입 시 중복 접속 확인 (학생 전용)
+	useEffect(() => {
+		if (isManager || !quizId || !sectionId || userRole === null) return;
+
+		const tryEnter = async () => {
+			try {
+				const res = await apiService.enterQuizSession(
+					sectionId,
+					quizId,
+					examClientSessionId,
+				);
+				const status =
+					(res as { data?: { status?: string }; status?: string })?.data
+						?.status ??
+					(res as { status?: string })?.status;
+				if (status === "CONFLICT") {
+					setExamSessionConflict(true);
+				}
+			} catch (err) {
+				console.error("시험 세션 진입 실패:", err);
+			}
+		};
+		tryEnter();
+
+		return () => {
+			// 페이지 이탈 시 세션 해제
+			apiService
+				.exitQuizSession(sectionId, quizId, examClientSessionId)
+				.catch(() => {});
+		};
+	}, [isManager, quizId, sectionId, userRole, examClientSessionId]);
+
+	// Heartbeat: 30초마다 세션 유효성 확인 및 TTL 연장
+	useEffect(() => {
+		if (isManager || !quizId || !sectionId || userRole === null || examSessionConflict) return;
+
+		const interval = setInterval(async () => {
+			try {
+				const res = await apiService.heartbeatQuizSession(
+					sectionId,
+					quizId,
+					examClientSessionId,
+				);
+				const valid =
+					(res as { data?: { valid?: boolean }; valid?: boolean })?.data
+						?.valid ??
+					(res as { valid?: boolean })?.valid;
+				if (valid === false) {
+					setExamSessionTakenOver(true);
+				}
+			} catch {
+				// 네트워크 오류는 무시 (TTL 내에서 자연 해제)
+			}
+		}, 30000);
+
+		return () => clearInterval(interval);
+	}, [isManager, quizId, sectionId, userRole, examSessionConflict, examClientSessionId]);
 
 	const loadFromSession = useCallback(async (): Promise<string | null> => {
 		if (!sessionId || !selectedProblemId || !sectionId) return null;
@@ -333,6 +400,17 @@ export function useCodingQuizSolve() {
 			console.warn("세션 데이터 정리 실패:", err);
 		}
 	}, [sessionId, selectedProblemId, sectionId, language]);
+
+	// "여기서 계속하기" - 기존 세션 강제 인계
+	const handleExamSessionTakeover = useCallback(async () => {
+		if (!quizId || !sectionId) return;
+		try {
+			await apiService.takeoverQuizSession(sectionId, quizId, examClientSessionId);
+			setExamSessionConflict(false);
+		} catch (err) {
+			console.error("세션 인계 실패:", err);
+		}
+	}, [quizId, sectionId, examClientSessionId]);
 
 	const handleTimeUp = useCallback(() => {
 		// 이미 처리된 경우 중복 실행 방지
@@ -598,6 +676,9 @@ export function useCodingQuizSolve() {
 		isProblemModalOpen,
 		setIsProblemModalOpen,
 		showSaveModal,
+		examSessionConflict,
+		examSessionTakenOver,
+		handleExamSessionTakeover,
 		handleTimeUp,
 		handleProblemChange,
 		handlePanelMove,

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/styles.ts
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/styles.ts
@@ -311,3 +311,72 @@ export const SaveModalContent = styled.div`
 export const SaveModalText = styled.span`
 	font-size: 16px;
 `;
+
+export const OverlayModal = styled.div`
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.75);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 9999;
+`;
+
+export const OverlayModalBox = styled.div`
+	background: #1e2533;
+	border: 1px solid #3a4258;
+	border-radius: 12px;
+	padding: 36px 40px;
+	max-width: 440px;
+	width: 90%;
+	text-align: center;
+`;
+
+export const OverlayModalTitle = styled.h2`
+	font-size: 18px;
+	font-weight: 700;
+	color: #f0f4ff;
+	margin: 0 0 16px;
+`;
+
+export const OverlayModalDesc = styled.p`
+	font-size: 14px;
+	color: #9aa3b8;
+	line-height: 1.7;
+	margin: 0 0 28px;
+`;
+
+export const OverlayModalButtons = styled.div`
+	display: flex;
+	gap: 12px;
+	justify-content: center;
+`;
+
+export const OverlayModalConfirm = styled.button`
+	padding: 10px 24px;
+	border-radius: 8px;
+	border: none;
+	background: #4f6ef7;
+	color: white;
+	font-size: 14px;
+	font-weight: 600;
+	cursor: pointer;
+	&:hover {
+		background: #3b5ce0;
+	}
+`;
+
+export const OverlayModalCancel = styled.button`
+	padding: 10px 24px;
+	border-radius: 8px;
+	border: 1px solid #3a4258;
+	background: transparent;
+	color: #9aa3b8;
+	font-size: 14px;
+	font-weight: 600;
+	cursor: pointer;
+	&:hover {
+		background: #2a3145;
+		color: #f0f4ff;
+	}
+`;

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -887,6 +887,50 @@ class APIService {
 		});
 	}
 
+	async enterQuizSession(
+		sectionId: number | string,
+		quizId: number | string,
+		sessionId: string,
+	): Promise<{ status: "OK" | "CONFLICT" }> {
+		return await this.request(
+			`/sections/${sectionId}/quizzes/${quizId}/session/enter`,
+			{ method: "POST", body: JSON.stringify({ sessionId }) },
+		);
+	}
+
+	async takeoverQuizSession(
+		sectionId: number | string,
+		quizId: number | string,
+		sessionId: string,
+	): Promise<{ status: string }> {
+		return await this.request(
+			`/sections/${sectionId}/quizzes/${quizId}/session/takeover`,
+			{ method: "POST", body: JSON.stringify({ sessionId }) },
+		);
+	}
+
+	async heartbeatQuizSession(
+		sectionId: number | string,
+		quizId: number | string,
+		sessionId: string,
+	): Promise<{ valid: boolean }> {
+		return await this.request(
+			`/sections/${sectionId}/quizzes/${quizId}/session/heartbeat`,
+			{ method: "POST", body: JSON.stringify({ sessionId }) },
+		);
+	}
+
+	async exitQuizSession(
+		sectionId: number | string,
+		quizId: number | string,
+		sessionId: string,
+	): Promise<void> {
+		await this.request(
+			`/sections/${sectionId}/quizzes/${quizId}/session/exit`,
+			{ method: "POST", body: JSON.stringify({ sessionId }) },
+		);
+	}
+
 	async getAssignmentSubmissionStats(
 		assignmentId: number | string,
 		sectionId: number | string,

--- a/src/utils/tokenManager.ts
+++ b/src/utils/tokenManager.ts
@@ -1,6 +1,10 @@
 /**
  * 토큰 매니저
- * Access Token은 localStorage에 저장, Refresh Token은 httpOnly 쿠키에서 처리
+ * - Access Token: 메모리(변수)에만 저장 → XSS로 탈취 불가
+ * - Refresh Token: HttpOnly 쿠키에서 처리 (JS에서 접근 불가)
+ *
+ * 페이지 새로고침 시 메모리가 초기화되지만, restoreAuth()가
+ * Refresh Token 쿠키를 이용해 Access Token을 자동 재발급합니다.
  */
 
 interface JwtPayload {
@@ -14,15 +18,9 @@ export interface TokenRefreshData {
 }
 
 class TokenManager {
-	private accessToken: string | null;
-	private onTokenRefresh: ((data: TokenRefreshData) => void) | null;
-	private onTokenExpired: (() => void) | null;
-
-	constructor() {
-		this.accessToken = this.getStoredAccessToken();
-		this.onTokenRefresh = null;
-		this.onTokenExpired = null;
-	}
+	private accessToken: string | null = null;
+	private onTokenRefresh: ((data: TokenRefreshData) => void) | null = null;
+	private onTokenExpired: (() => void) | null = null;
 
 	setCallbacks(
 		onTokenRefresh: ((data: TokenRefreshData) => void) | null,
@@ -32,30 +30,8 @@ class TokenManager {
 		this.onTokenExpired = onTokenExpired;
 	}
 
-	getStoredAccessToken(): string | null {
-		try {
-			return localStorage.getItem("accessToken");
-		} catch (error) {
-			console.error("localStorage 접근 오류:", error);
-			return null;
-		}
-	}
-
-	private setStoredAccessToken(token: string | null): void {
-		try {
-			if (token) {
-				localStorage.setItem("accessToken", token);
-			} else {
-				localStorage.removeItem("accessToken");
-			}
-		} catch (error) {
-			console.error("localStorage 저장 오류:", error);
-		}
-	}
-
 	setAccessToken(token: string | null): void {
 		this.accessToken = token;
-		this.setStoredAccessToken(token);
 	}
 
 	getAccessToken(): string | null {
@@ -64,7 +40,6 @@ class TokenManager {
 
 	clearTokens(): void {
 		this.accessToken = null;
-		this.setStoredAccessToken(null);
 	}
 
 	isTokenValid(): boolean {
@@ -105,7 +80,7 @@ class TokenManager {
 				process.env.REACT_APP_API_URL ?? "https://hcl.walab.info/api";
 			const response = await fetch(`${apiUrl}/auth/refresh`, {
 				method: "POST",
-				credentials: "include",
+				credentials: "include", // Refresh Token 쿠키 자동 전송
 				headers: { "Content-Type": "application/json" },
 			});
 
@@ -128,22 +103,24 @@ class TokenManager {
 		this.onTokenExpired?.();
 	}
 
+	/**
+	 * 앱 초기화 시 인증 복원
+	 * 메모리에 토큰이 없으면 Refresh Token 쿠키로 자동 재발급 시도
+	 */
 	async restoreAuth(): Promise<{ accessToken: string } | null> {
-		const token = this.getStoredAccessToken();
-		if (token && !this.isTokenExpired(token)) {
-			this.accessToken = token;
-			return { accessToken: token };
+		// 메모리에 유효한 토큰이 있으면 그대로 사용
+		if (this.accessToken && !this.isTokenExpired(this.accessToken)) {
+			return { accessToken: this.accessToken };
 		}
-		// Access Token이 만료됐어도 Refresh Token 쿠키로 재발급 시도
-		if (token) {
-			try {
-				const refreshed = await this.refreshToken();
-				if (refreshed.accessToken) {
-					return { accessToken: refreshed.accessToken };
-				}
-			} catch {
-				// Refresh Token도 만료됨 → null 반환
+
+		// 메모리 토큰이 없거나 만료됨 → Refresh Token 쿠키로 재발급 시도
+		try {
+			const refreshed = await this.refreshToken();
+			if (refreshed.accessToken) {
+				return { accessToken: refreshed.accessToken };
 			}
+		} catch {
+			// Refresh Token도 만료됨 → 로그인 필요
 		}
 		return null;
 	}


### PR DESCRIPTION
Switch access-token handling to memory-only refresh recovery and wire coding-quiz solve pages to session enter/takeover/heartbeat/exit APIs. Show explicit conflict/taken-over modals so students can safely continue from one active solve session.


## #️⃣연관된 이슈

> #162 