### PR TITLE
fix/issue-90/성적부분코드집및제출csv처리

### DIFF
--- a/src/hooks/useAssignmentProblems.ts
+++ b/src/hooks/useAssignmentProblems.ts
@@ -16,6 +16,7 @@ interface Assignment {
 
 export const useAssignmentProblems = () => {
   const [availableProblems, setAvailableProblems] = useState<Problem[]>([]);
+  const [loadingAvailableProblems, setLoadingAvailableProblems] = useState(false);
   const [copyableProblems, setCopyableProblems] = useState<Problem[]>([]);
   const [assignmentsForProblem, setAssignmentsForProblem] = useState<Assignment[]>([]);
   const [assignmentProblems, setAssignmentProblems] = useState<Record<number, Problem[]>>({});
@@ -23,6 +24,7 @@ export const useAssignmentProblems = () => {
   const [loadingAssignmentsForProblem, setLoadingAssignmentsForProblem] = useState(false);
 
   const fetchAvailableProblems = useCallback(async () => {
+    setLoadingAvailableProblems(true);
     try {
       const response = await APIService.getAllProblems();
       const problems = response.data || response || [];
@@ -30,6 +32,8 @@ export const useAssignmentProblems = () => {
     } catch (error) {
       console.error("사용 가능한 문제 조회 실패:", error);
       setAvailableProblems([]);
+    } finally {
+      setLoadingAvailableProblems(false);
     }
   }, []);
 
@@ -109,6 +113,7 @@ export const useAssignmentProblems = () => {
 
   return {
     availableProblems,
+    loadingAvailableProblems,
     setAvailableProblems,
     copyableProblems,
     setCopyableProblems,

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/ProblemSelectModal.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/ProblemSelectModal.tsx
@@ -378,7 +378,7 @@ function AssignmentSourceProblemPicker({
 					</PS.AddModalSearchRow>
 				)}
 
-				{sourceLoading && sourceProblems.length === 0 ? (
+				{sectionTab !== "added" && sourceLoading ? (
 					<div
 						style={{
 							minHeight: 280,
@@ -542,6 +542,7 @@ function AssignmentSourceProblemPicker({
 const ProblemSelectModal: React.FC<ProblemSelectModalProps> = ({
 	isOpen,
 	selectedAssignment,
+	instructorProblemsLoading = false,
 	instructorProblems,
 	filteredProblems: _filteredProblems,
 	selectedProblemIds,
@@ -782,7 +783,7 @@ const ProblemSelectModal: React.FC<ProblemSelectModalProps> = ({
 					{activeMode === "problems" && selectedAssignment && (
 						<AssignmentSourceProblemPicker
 							sourceProblems={instructorProblems as Problem[]}
-							sourceLoading={false}
+							sourceLoading={instructorProblemsLoading}
 							sourceContextKey={`inst-${selectedAssignment.id}`}
 							allSubtitle="전체 문제 (내 문제 라이브러리)"
 							selectedAssignment={selectedAssignment}

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/types.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/ProblemModals/types.ts
@@ -19,6 +19,8 @@ export interface BulkProblemData {
 export interface ProblemSelectModalProps {
 	isOpen: boolean;
 	selectedAssignment: { id: number; title?: string; sectionId?: number } | null;
+	/** 내 문제 탭: `getAllProblems` 로딩 중 */
+	instructorProblemsLoading?: boolean;
 	/** 내 문제 탭: 전체 문제 목록(API). 필터·검색은 모달 내부에서 처리 */
 	instructorProblems: {
 		id: number;

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/hooks/useAssignmentManagement.ts
@@ -44,6 +44,7 @@ export function useAssignmentManagement() {
 		useSubmissionStats(assignments, sectionId ?? null);
 	const {
 		availableProblems,
+		loadingAvailableProblems,
 		assignmentsForProblem,
 		setAssignmentsForProblem,
 		assignmentProblems,
@@ -1032,6 +1033,7 @@ export function useAssignmentManagement() {
 		showProblemModal,
 		setShowProblemModal,
 		availableProblems,
+		loadingAvailableProblems,
 		filteredProblems,
 		selectedProblemIds,
 		problemSearchTerm,

--- a/src/pages/TutorPage/Assignments/AssignmentManagement/index.tsx
+++ b/src/pages/TutorPage/Assignments/AssignmentManagement/index.tsx
@@ -176,6 +176,7 @@ const AssignmentManagement: React.FC = () => {
 			<ProblemSelectModal
 				isOpen={d.showProblemModal}
 				selectedAssignment={d.selectedAssignment}
+				instructorProblemsLoading={d.loadingAvailableProblems}
 				instructorProblems={d.availableProblems}
 				filteredProblems={d.filteredProblems}
 				selectedProblemIds={d.selectedProblemIds}

--- a/src/pages/TutorPage/CodingTests/CodingTestManagement/components/AddProblemsToQuizModal.tsx
+++ b/src/pages/TutorPage/CodingTests/CodingTestManagement/components/AddProblemsToQuizModal.tsx
@@ -366,7 +366,7 @@ const QuizProblemPickerPanel: FC<QuizProblemPickerPanelProps> = ({
 					</PS.AddModalSearchRow>
 				)}
 
-				{sourceLoading && sourceProblems.length === 0 && sectionTab !== "added" ? (
+				{sectionTab !== "added" && sourceLoading ? (
 					<div
 						style={{
 							minHeight: 280,
@@ -805,7 +805,7 @@ const AddProblemsToQuizModal: FC<AddProblemsToQuizModalProps> = ({ d }) => {
 						<QuizProblemPickerPanel
 							d={d}
 							sourceProblems={d.allProblems as ProblemWithMeta[]}
-							sourceLoading={false}
+							sourceLoading={d.loadingAllProblems}
 							sourceContextKey="quiz-my-problems"
 							allSubtitle="전체 문제 (내 문제 라이브러리)"
 							idToSource={mergedIdToSource}

--- a/src/pages/TutorPage/CodingTests/CodingTestManagement/hooks/useCodingTestManagement.ts
+++ b/src/pages/TutorPage/CodingTests/CodingTestManagement/hooks/useCodingTestManagement.ts
@@ -72,6 +72,7 @@ export function useCodingTestManagement() {
 	});
 	const [selectedProblemIds, setSelectedProblemIds] = useState<number[]>([]);
 	const [allProblems, setAllProblems] = useState<ProblemOption[]>([]);
+	const [loadingAllProblems, setLoadingAllProblems] = useState(false);
 	const [problemSearchTerm, setProblemSearchTerm] = useState("");
 	const [currentProblemPage, setCurrentProblemPage] = useState(1);
 	const [isSubmittingCreate, setIsSubmittingCreate] = useState(false);
@@ -331,6 +332,7 @@ export function useCodingTestManagement() {
 	}, [sectionId, quizId]);
 
 	const fetchAllProblems = useCallback(async () => {
+		setLoadingAllProblems(true);
 		try {
 			const response = await APIService.getAllProblems();
 			let problemsData: ProblemOption[] = [];
@@ -347,6 +349,8 @@ export function useCodingTestManagement() {
 		} catch (error) {
 			console.error("문제 목록 조회 실패:", error);
 			setAllProblems([]);
+		} finally {
+			setLoadingAllProblems(false);
 		}
 	}, []);
 
@@ -882,6 +886,7 @@ export function useCodingTestManagement() {
 		selectedProblemIds,
 		setSelectedProblemIds,
 		allProblems,
+		loadingAllProblems,
 		problemSearchTerm,
 		setProblemSearchTerm,
 		currentProblemPage,

--- a/src/pages/TutorPage/Grades/GradeManagement/hooks/useGradeManagement.ts
+++ b/src/pages/TutorPage/Grades/GradeManagement/hooks/useGradeManagement.ts
@@ -774,33 +774,19 @@ export function useGradeManagement() {
 			if (dueAt && new Date() > new Date(dueAt)) return '"미제출"';
 			return '""';
 		};
+		/** API ISO(UTC Z 등)와 로컬 naive 문자열 모두 브라우저 Date가 instant로 해석하도록 통일 */
+		const parseInstantMs = (raw?: string): number => {
+			if (!raw?.trim()) return Number.NaN;
+			const ms = new Date(raw.trim().replace(" ", "T")).getTime();
+			return Number.isNaN(ms) ? Number.NaN : ms;
+		};
 		const getLateMinutesForCSV = (
 			submittedAt: string | undefined,
 			dueAt: string | undefined,
 		): number => {
 			if (!submittedAt || !dueAt) return 0;
-			const parse = (raw?: string): number => {
-				if (!raw) return Number.NaN;
-				const normalized = raw.trim().replace(" ", "T");
-				const m = normalized
-					.trim()
-					.match(
-						/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?/,
-					);
-				if (!m) return new Date(normalized).getTime();
-				const ms = Number((m[7] ?? "0").slice(0, 3).padEnd(3, "0"));
-				return new Date(
-					Number(m[1]),
-					Number(m[2]) - 1,
-					Number(m[3]),
-					Number(m[4]),
-					Number(m[5]),
-					Number(m[6] ?? "0"),
-					ms,
-				).getTime();
-			};
-			const s = parse(submittedAt);
-			const d = parse(dueAt);
+			const s = parseInstantMs(submittedAt);
+			const d = parseInstantMs(dueAt);
 			if (Number.isNaN(s) || Number.isNaN(d) || s <= d) return 0;
 			return Math.floor((s - d) / 60000);
 		};


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #190 
## 📝작업 내용

# [FE] 성적 CSV보내기 · 지각 시간 계산 시각 통일

## 배경 / 목적
- 성적 관리 화면에서 CSV로보낼 때, **제출 시각·마감 시각** 문자열 형식이 API(ISO/UTC `Z` 등)와 로컬 naive 형식이 섞이면 브라우저 `Date` 파싱이 달라져 **지각 시간(분)** 이 어긋날 수 있다.
- **한 instant 기준**으로 비교하도록 파싱을 통일한다.

---

## 문제
- `submittedAt`, `dueAt`를 그대로 `new Date(...)`만 쓰면, 공백 구분 ISO 문자열 등에서 환경/형식에 따라 해석이 달라질 수 있음.
- CSV의 “지각시간” 컬럼이 백엔드·ZIP 메타와 불일치할 위험.

---

## 해결 방향
- `useGradeManagement.ts`의 `handleExportCSV` 내부에 `parseInstantMs` 헬퍼 추가:
  - 문자열 trim 후 **첫 공백을 `T`로 치환** (`replace(" ", "T")`)하여 `YYYY-MM-DDTHH:mm:ss…` 형태로 맞춘 뒤 `new Date(...).getTime()`으로 ms 변환.
  - API ISO(UTC `Z` 등)와 naive 형식 모두 브라우저가 **동일한 instant**로 해석하기 쉽게 함.
- `getLateMinutesForCSV` / `formatLateDurationForCSV`에서 제출·마감 비교 시 위 `parseInstantMs` 사용.

### 관련 코드
- `Handongjudge_FE/src/pages/TutorPage/Grades/GradeManagement/hooks/useGradeManagement.ts`
  - `handleExportCSV` 내 `parseInstantMs`, `getLateMinutesForCSV`, `formatLateDurationForCSV`

---

## 수동 테스트
1. 과제/퀴즈 성적 CSV보내기.
2. 동일 학생·동일 문제에 대해 API로 내려오는 `submittedAt` / `dueAt`와 CSV의 지각 분/지각시간 문자열이 기대와 일치하는지 확인 (특히 UTC `Z` 응답).
3. 마감 전 제출 → 지각 0 또는 빈 값.
4. 마감 후 제출 → 분 단위 지각이 음수가 아니고, 일/시간/분 표기가 자연스러운지 확인.

---

## (선택) 연관 UI
- 성적 셀에 맞은 테스트케이스 수 표시(`passedTestCases` / `totalTestCases`) 등 백엔드 DTO 확장이 있다면, 별도 이슈로 “표시 컴포넌트·타입 정의”를 나누어 적을 수 있음.

---

## 체크리스트
- [ ] `pnpm`/`npm` 빌드·린트 통과
- [ ] CSV 지각 컬럼 샘플 데이터로 회귀 확인