### PR TITLE
fix/issue-200/커뮤니티수정사항

### DIFF
--- a/src/components/Editor/TipTapEditor/TipTapEditor.css
+++ b/src/components/Editor/TipTapEditor/TipTapEditor.css
@@ -190,31 +190,6 @@
 	color: #d4d4d4;
 }
 
-.code-language-select {
-	padding: 4px 8px;
-	border: 1px solid #e0e0e0;
-	border-radius: 4px;
-	background: white;
-	font-size: 13px;
-	color: #4a5568;
-	cursor: pointer;
-	transition: all 0.15s;
-	min-width: 120px;
-	height: 28px;
-	margin-left: 4px;
-}
-
-.code-language-select:hover {
-	border-color: #cbd5e0;
-	background: #f7fafc;
-}
-
-.code-language-select:focus {
-	outline: none;
-	border-color: #667eea;
-	box-shadow: 0 0 0 2px rgba(102, 126, 234, 0.1);
-}
-
 .tiptap-editor code {
 	background: #f1f3f5;
 	color: #e83e8c;

--- a/src/components/Editor/TipTapEditor/index.tsx
+++ b/src/components/Editor/TipTapEditor/index.tsx
@@ -10,33 +10,7 @@ import { MdImage } from "react-icons/md";
 import hljs from "highlight.js";
 import "highlight.js/styles/vs2015.css";
 import "./styles";
-import type { TipTapEditorProps, CodeLanguageOption } from "./types";
-
-const CODE_LANGUAGES: CodeLanguageOption[] = [
-	{ value: "", label: "언어 선택" },
-	{ value: "javascript", label: "JavaScript" },
-	{ value: "typescript", label: "TypeScript" },
-	{ value: "python", label: "Python" },
-	{ value: "java", label: "Java" },
-	{ value: "cpp", label: "C++" },
-	{ value: "c", label: "C" },
-	{ value: "csharp", label: "C#" },
-	{ value: "html", label: "HTML" },
-	{ value: "css", label: "CSS" },
-	{ value: "json", label: "JSON" },
-	{ value: "sql", label: "SQL" },
-	{ value: "bash", label: "Bash" },
-	{ value: "shell", label: "Shell" },
-	{ value: "go", label: "Go" },
-	{ value: "rust", label: "Rust" },
-	{ value: "php", label: "PHP" },
-	{ value: "ruby", label: "Ruby" },
-	{ value: "swift", label: "Swift" },
-	{ value: "kotlin", label: "Kotlin" },
-	{ value: "markdown", label: "Markdown" },
-	{ value: "yaml", label: "YAML" },
-	{ value: "xml", label: "XML" },
-];
+import type { TipTapEditorProps } from "./types";
 
 const TipTapEditor: React.FC<TipTapEditorProps> = ({
 	content,
@@ -127,34 +101,6 @@ const TipTapEditor: React.FC<TipTapEditorProps> = ({
 		return attrs.fontSize ?? "";
 	};
 
-	const getCurrentCodeBlockLanguage = () => {
-		if (!editor) return "";
-		const attrs = editor.getAttributes("codeBlock");
-		return attrs.language ?? "";
-	};
-
-	const handleCodeBlockLanguageChange = (language: string) => {
-		if (!editor) return;
-		try {
-			editor
-				.chain()
-				.focus()
-				.updateAttributes("codeBlock", {
-					language: language || null,
-				})
-				.run();
-			setTimeout(() => {
-				try {
-					if (editor?.view?.dom) highlightCodeBlocks();
-				} catch (err) {
-					console.warn("언어 변경 후 하이라이팅 실패:", err);
-				}
-			}, 100);
-		} catch (err) {
-			console.warn("코드 블록 언어 변경 실패:", err);
-		}
-	};
-
 	const highlightCodeBlocks = useCallback(() => {
 		try {
 			if (!editor?.view?.dom) return;
@@ -234,8 +180,6 @@ const TipTapEditor: React.FC<TipTapEditorProps> = ({
 
 	if (!editor) return null;
 
-	const isCodeBlockActive = editor.isActive("codeBlock");
-
 	return (
 		<div className="tiptap-editor-wrapper">
 			<div className="tiptap-toolbar">
@@ -304,23 +248,6 @@ const TipTapEditor: React.FC<TipTapEditorProps> = ({
 				>
 					{"<>"}
 				</button>
-				{isCodeBlockActive && (
-					<select
-						className="code-language-select"
-						value={getCurrentCodeBlockLanguage()}
-						onChange={(e) => handleCodeBlockLanguageChange(e.target.value)}
-						title="언어 선택"
-						onClick={(e) => e.stopPropagation()}
-						onKeyDown={(e) => e.stopPropagation()}
-						aria-label="코드 블록 언어"
-					>
-						{CODE_LANGUAGES.map((lang) => (
-							<option key={lang.value} value={lang.value}>
-								{lang.label}
-							</option>
-						))}
-					</select>
-				)}
 				<button
 					type="button"
 					onClick={() => editor.chain().focus().toggleBlockquote().run()}

--- a/src/components/Editor/TipTapEditor/types.ts
+++ b/src/components/Editor/TipTapEditor/types.ts
@@ -3,8 +3,3 @@ export interface TipTapEditorProps {
 	onChange: (html: string) => void;
 	placeholder?: string;
 }
-
-export interface CodeLanguageOption {
-	value: string;
-	label: string;
-}

--- a/src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx
@@ -37,7 +37,6 @@ interface ProblemSolveViewProps {
 	verticalSizes: number[];
 	panelLayout: { left: PanelKey; topRight: PanelKey; bottomRight: PanelKey };
 	handlePanelMove: (dragged: string, target: string) => void;
-	handleLanguageChange: (lang: string) => void;
 	handleSubmit: () => void;
 	handleSubmitWithOutput: () => void;
 	saveToSession: () => void;
@@ -77,7 +76,6 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 		verticalSizes,
 		panelLayout,
 		handlePanelMove,
-		handleLanguageChange,
 		handleSubmit,
 		handleSubmitWithOutput,
 		saveToSession,
@@ -197,15 +195,6 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 						>
 							Dark
 						</S.ThemeButton>
-						<S.LanguageSelect
-							$theme={theme}
-							value={language}
-							onChange={(e) => handleLanguageChange(e.target.value)}
-							disabled
-							style={{ opacity: 0.7, cursor: "not-allowed" }}
-						>
-							<option value="c">C</option>
-						</S.LanguageSelect>
 					</S.Controls>
 				</S.Header>
 

--- a/src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts
+++ b/src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts
@@ -405,11 +405,6 @@ export function useProblemSolve() {
 		[],
 	);
 
-	const handleLanguageChange = useCallback((newLang: string) => {
-		setLanguage(newLang);
-		setCode(getDefaultCode(newLang));
-	}, []);
-
 	const handleSubmit = useCallback(async () => {
 		if (!code.trim()) {
 			alert("코드를 작성해주세요.");
@@ -620,7 +615,6 @@ export function useProblemSolve() {
 		verticalSizes,
 		panelLayout,
 		handlePanelMove,
-		handleLanguageChange,
 		handleSubmit,
 		handleSubmitWithOutput,
 		saveToSession,

--- a/src/pages/AssignmentPage/ProblemSolvePage/index.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/index.tsx
@@ -42,7 +42,6 @@ const ProblemSolvePage: React.FC = () => {
 			verticalSizes={hook.verticalSizes}
 			panelLayout={hook.panelLayout}
 			handlePanelMove={hook.handlePanelMove}
-			handleLanguageChange={hook.handleLanguageChange}
 			handleSubmit={hook.handleSubmit}
 			handleSubmitWithOutput={hook.handleSubmitWithOutput}
 			saveToSession={hook.saveToSession}

--- a/src/pages/AssignmentPage/ProblemSolvePage/styles.ts
+++ b/src/pages/AssignmentPage/ProblemSolvePage/styles.ts
@@ -190,14 +190,6 @@ export const ThemeButton = styled.button<{
 	`}
 `;
 
-export const LanguageSelect = styled.select<{ $theme: "light" | "dark" }>`
-	padding: 4px 10px;
-	border-radius: 4px;
-	background-color: ${(p) => (p.$theme === "light" ? "#ffffff" : "#21262d")};
-	color: ${(p) => (p.$theme === "light" ? "#000000" : "#c9d1d9")};
-	border: 1px solid ${(p) => (p.$theme === "light" ? "#e1e4e8" : "#30363d")};
-`;
-
 export const MainSplit = styled.div`
 	flex: 1;
 	display: flex;

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/components/CodingQuizSolveView.tsx
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/components/CodingQuizSolveView.tsx
@@ -220,14 +220,6 @@ export default function CodingQuizSolveView(d: UseCodingQuizSolveReturn) {
 						>
 							Dark
 						</S.ThemeButton>
-						<S.LanguageSelect
-							$theme={d.theme}
-							value={d.language}
-							onChange={(e) => d.handleLanguageChange(e.target.value)}
-							disabled
-						>
-							<option value="c">C</option>
-						</S.LanguageSelect>
 					</S.Controls>
 				</S.Header>
 

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/hooks/useCodingQuizSolve.ts
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/hooks/useCodingQuizSolve.ts
@@ -801,12 +801,6 @@ export function useCodingQuizSolve() {
 		await pollUntilResult("output");
 	}, [pollUntilResult]);
 
-	const handleLanguageChange = useCallback((newLang: string) => {
-		if (newLang !== "c") return;
-		setLanguage(newLang);
-		setCode(getDefaultCode(newLang));
-	}, []);
-
 	const handleHorizontalDragEnd = useCallback((sizes: number[]) => {
 		setHorizontalSizes(sizes);
 	}, []);
@@ -866,7 +860,6 @@ export function useCodingQuizSolve() {
 		handleSubmit,
 		handleSubmitWithOutput,
 		saveToBackend,
-		handleLanguageChange,
 		handleHorizontalDragEnd,
 		handleVerticalDragEnd,
 		gutterStyleCallback,

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/styles.ts
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/styles.ts
@@ -196,23 +196,6 @@ export const ThemeButton = styled.button<{
 	`}
 `;
 
-export const LanguageSelect = styled.select<{ $theme: "light" | "dark" }>`
-	padding: 4px 10px;
-	border-radius: 4px;
-	background-color: ${(p) => (p.$theme === "light" ? "#ffffff" : "#21262d")};
-	color: ${(p) => (p.$theme === "light" ? "#000000" : "#c9d1d9")};
-	border: 1px solid ${(p) => (p.$theme === "light" ? "#e1e4e8" : "#30363d")};
-	appearance: none;
-	-webkit-appearance: none;
-	-moz-appearance: none;
-	background-image: none;
-	padding-right: 10px;
-
-	&::-ms-expand {
-		display: none;
-	}
-`;
-
 export const MainSplit = styled.div`
 	flex: 1;
 	display: flex;

--- a/src/pages/Course/Community/CourseCommunityPage/QuestionCard.tsx
+++ b/src/pages/Course/Community/CourseCommunityPage/QuestionCard.tsx
@@ -36,6 +36,15 @@ const QuestionCard: React.FC<QuestionCardProps> = ({ question, onClick }) => (
           <span className="author">
             {question.authorDisplayName ?? question.authorName ?? "익명"}
           </span>
+          {question.isAuthor && <S.MyPostBadge>내 글</S.MyPostBadge>}
+          {question.authorRealNameForStaff ? (
+            <>
+              <S.Separator>·</S.Separator>
+              <S.StaffAuthorNote>
+                실명: {question.authorRealNameForStaff}
+              </S.StaffAuthorNote>
+            </>
+          ) : null}
           <S.Separator>·</S.Separator>
           <span className="date">{formatDate(question.createdAt)}</span>
         </S.AuthorDate>

--- a/src/pages/Course/Community/CourseCommunityPage/styles.ts
+++ b/src/pages/Course/Community/CourseCommunityPage/styles.ts
@@ -353,11 +353,29 @@ export const AuthorDate = styled.div`
   gap: 6px;
   font-size: 12px;
   color: #666;
+  flex-wrap: wrap;
 
   .author {
     font-weight: 500;
     color: #1a1a1a;
   }
+`;
+
+export const MyPostBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  background: #e8edff;
+  color: #4c51bf;
+`;
+
+export const StaffAuthorNote = styled.span`
+  font-size: 11px;
+  color: #805ad5;
+  font-weight: 500;
 `;
 
 export const QuestionTitleText = styled.h3`

--- a/src/pages/Course/Community/CourseCommunityPage/types.ts
+++ b/src/pages/Course/Community/CourseCommunityPage/types.ts
@@ -8,6 +8,12 @@ export interface Question {
 	status: "PENDING" | "RESOLVED";
 	isPinned?: boolean;
 	isAnonymous?: boolean;
+	isPublic?: boolean;
+	/** 목록 API: 현재 사용자 작성 여부 */
+	isAuthor?: boolean;
+	/** 교수/TA만 수신 */
+	authorRealNameForStaff?: string;
+	authorId?: number;
 	viewCount: number;
 	commentCount: number;
 	likeCount: number;
@@ -22,6 +28,8 @@ export interface SectionInfo {
 	sectionId?: number;
 	courseTitle?: string;
 	courseName?: string;
+	instructorId?: number;
+	isCurrentUserSectionStaff?: boolean;
 }
 
 export interface Stats {

--- a/src/pages/Course/Community/QuestionCreatePage/components/QuestionCreatePageView.tsx
+++ b/src/pages/Course/Community/QuestionCreatePage/components/QuestionCreatePageView.tsx
@@ -17,17 +17,9 @@ export default function QuestionCreatePageView(
 		assignmentsWithProblems,
 		formData,
 		setFormData,
-		nickname,
-		showNicknameModal,
-		setShowNicknameModal,
-		nicknameInput,
-		setNicknameInput,
-		nicknameError,
-		setNicknameError,
 		getSelectValue,
 		handleSelectChange,
 		handleSubmit,
-		handleNicknameSubmit,
 		handleToggleSidebar,
 	} = d;
 
@@ -143,17 +135,50 @@ export default function QuestionCreatePageView(
 											setFormData((prev) => ({
 												...prev,
 												isAnonymous: e.target.checked,
+												anonymousUseNickname: e.target.checked
+													? prev.anonymousUseNickname
+													: true,
 											}))
 										}
 										aria-label="익명으로 질문하기"
 									/>
 									<span>익명으로 질문하기</span>
-									{formData.isAnonymous && nickname && (
-										<S.NicknameDisplay>(별명: {nickname})</S.NicknameDisplay>
-									)}
 								</S.OptionLabel>
+								{formData.isAnonymous && (
+									<S.AnonymousChoiceRow>
+										<S.RadioChoice>
+											<input
+												type="radio"
+												name="anon-display"
+												checked={formData.anonymousUseNickname}
+												onChange={() =>
+													setFormData((prev) => ({
+														...prev,
+														anonymousUseNickname: true,
+													}))
+												}
+											/>
+											<span>무작위 별칭으로 표시 (형용사+동물 등)</span>
+										</S.RadioChoice>
+										<S.RadioChoice>
+											<input
+												type="radio"
+												name="anon-display"
+												checked={!formData.anonymousUseNickname}
+												onChange={() =>
+													setFormData((prev) => ({
+														...prev,
+														anonymousUseNickname: false,
+													}))
+												}
+											/>
+											<span>게시에는 '익명'으로만 표시</span>
+										</S.RadioChoice>
+									</S.AnonymousChoiceRow>
+								)}
 								<S.OptionDescription>
-									익명으로 질문하면 이름 대신 별명이 표시됩니다
+									무작위 별칭은 서버에서 이 수업 안에서 겹치지 않게 정해집니다.
+									교수·TA는 작성자 실명을 볼 수 있습니다.
 								</S.OptionDescription>
 							</S.OptionGroup>
 
@@ -192,63 +217,6 @@ export default function QuestionCreatePageView(
 					</S.Form>
 				</S.Body>
 			</S.Content>
-
-			{showNicknameModal && (
-				<S.ModalOverlay
-					onClick={() => setShowNicknameModal(false)}
-					role="button"
-					tabIndex={0}
-					onKeyDown={(e) => {
-						if (e.key === "Escape" || e.key === "Enter") {
-							setShowNicknameModal(false);
-						}
-					}}
-					aria-label="닫기"
-				>
-					<S.ModalContent
-						onClick={(e) => e.stopPropagation()}
-						role="dialog"
-						aria-modal="true"
-						aria-labelledby="nickname-modal-title"
-					>
-						<h2 id="nickname-modal-title">별명 설정</h2>
-						<p>익명으로 질문하려면 별명을 설정해주세요</p>
-						<S.ModalFormGroup>
-							<input
-								type="text"
-								placeholder="별명 입력 (2-50자)"
-								value={nicknameInput}
-								onChange={(e) => {
-									setNicknameInput(e.target.value);
-									setNicknameError("");
-								}}
-								maxLength={50}
-								aria-label="별명 입력"
-							/>
-							{nicknameError && (
-								<S.ErrorMessage>{nicknameError}</S.ErrorMessage>
-							)}
-						</S.ModalFormGroup>
-						<S.ModalActions>
-							<S.BtnModalCancel
-								type="button"
-								onClick={() => {
-									setShowNicknameModal(false);
-									setFormData((prev) => ({
-										...prev,
-										isAnonymous: false,
-									}));
-								}}
-							>
-								취소
-							</S.BtnModalCancel>
-							<S.BtnModalSubmit type="button" onClick={handleNicknameSubmit}>
-								설정
-							</S.BtnModalSubmit>
-						</S.ModalActions>
-					</S.ModalContent>
-				</S.ModalOverlay>
-			)}
 		</S.Container>
 	);
 }

--- a/src/pages/Course/Community/QuestionCreatePage/hooks/useQuestionCreatePage.ts
+++ b/src/pages/Course/Community/QuestionCreatePage/hooks/useQuestionCreatePage.ts
@@ -9,6 +9,7 @@ const initialFormData: QuestionFormData = {
 	title: "",
 	content: "",
 	isAnonymous: false,
+	anonymousUseNickname: true,
 	isPublic: true,
 	assignmentId: "",
 	problemId: "",
@@ -27,10 +28,6 @@ export function useQuestionCreatePage() {
 		Assignment[]
 	>([]);
 	const [formData, setFormData] = useState<QuestionFormData>(initialFormData);
-	const [nickname, setNickname] = useState("");
-	const [showNicknameModal, setShowNicknameModal] = useState(false);
-	const [nicknameInput, setNicknameInput] = useState("");
-	const [nicknameError, setNicknameError] = useState("");
 
 	const fetchInitialData = useCallback(async () => {
 		if (!sectionId) return;
@@ -68,68 +65,9 @@ export function useQuestionCreatePage() {
 		}
 	}, [sectionId]);
 
-	const fetchNickname = useCallback(async () => {
-		if (!sectionId) return;
-		try {
-			const data = await APIService.request(
-				`/community/nicknames?sectionId=${sectionId}`,
-			);
-			if (data?.success && data?.data?.nickname) {
-				setNickname(data.data.nickname);
-			} else {
-				setShowNicknameModal(true);
-			}
-		} catch (err) {
-			console.error("Error fetching nickname:", err);
-			setShowNicknameModal(true);
-		}
-	}, [sectionId]);
-
 	useEffect(() => {
 		fetchInitialData();
 	}, [fetchInitialData]);
-
-	useEffect(() => {
-		if (formData.isAnonymous && !nickname) {
-			fetchNickname();
-		}
-	}, [formData.isAnonymous, nickname, fetchNickname]);
-
-	const handleNicknameSubmit = useCallback(async () => {
-		if (!nicknameInput.trim()) {
-			setNicknameError("별명을 입력해주세요");
-			return;
-		}
-		if (nicknameInput.length < 2 || nicknameInput.length > 50) {
-			setNicknameError("별명은 2-50자 사이여야 합니다");
-			return;
-		}
-		if (!sectionId) return;
-		try {
-			const checkData = await APIService.request(
-				`/community/nicknames/check?sectionId=${sectionId}&nickname=${encodeURIComponent(nicknameInput)}`,
-			);
-			if (!checkData?.data?.isAvailable) {
-				setNicknameError("이미 사용 중인 별명입니다");
-				return;
-			}
-			const data = await APIService.request("/community/nicknames", {
-				method: "POST",
-				body: JSON.stringify({
-					sectionId: Number.parseInt(sectionId, 10),
-					nickname: nicknameInput,
-				}),
-			});
-			if (data?.success) {
-				setNickname(data.data.nickname);
-				setShowNicknameModal(false);
-				setNicknameError("");
-			}
-		} catch (err) {
-			console.error("Error setting nickname:", err);
-			setNicknameError("별명 설정 중 오류가 발생했습니다");
-		}
-	}, [sectionId, nicknameInput]);
 
 	const getSelectValue = useCallback((): string => {
 		if (formData.assignmentId && formData.problemId) {
@@ -190,11 +128,6 @@ export function useQuestionCreatePage() {
 				alert("내용을 입력해주세요");
 				return;
 			}
-			if (formData.isAnonymous && !nickname) {
-				alert("익명으로 질문하려면 별명을 설정해주세요");
-				setShowNicknameModal(true);
-				return;
-			}
 			try {
 				setLoading(true);
 				const requestData: Record<string, unknown> = {
@@ -204,6 +137,9 @@ export function useQuestionCreatePage() {
 					isAnonymous: formData.isAnonymous,
 					isPublic: formData.isPublic,
 				};
+				if (formData.isAnonymous) {
+					requestData.anonymousUseNickname = formData.anonymousUseNickname;
+				}
 				if (formData.assignmentId) {
 					requestData.assignmentId = Number.parseInt(formData.assignmentId, 10);
 				}
@@ -228,7 +164,7 @@ export function useQuestionCreatePage() {
 				setLoading(false);
 			}
 		},
-		[sectionId, formData, nickname, navigate],
+		[sectionId, formData, navigate],
 	);
 
 	const handleToggleSidebar = useCallback(() => {
@@ -244,17 +180,9 @@ export function useQuestionCreatePage() {
 		assignmentsWithProblems,
 		formData,
 		setFormData,
-		nickname,
-		showNicknameModal,
-		setShowNicknameModal,
-		nicknameInput,
-		setNicknameInput,
-		nicknameError,
-		setNicknameError,
 		getSelectValue,
 		handleSelectChange,
 		handleSubmit,
-		handleNicknameSubmit,
 		handleToggleSidebar,
 	};
 }

--- a/src/pages/Course/Community/QuestionCreatePage/styles.ts
+++ b/src/pages/Course/Community/QuestionCreatePage/styles.ts
@@ -163,6 +163,28 @@ export const OptionDescription = styled.p`
   color: #666;
 `;
 
+export const AnonymousChoiceRow = styled.div`
+  margin: 10px 0 0 26px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const RadioChoice = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  color: #333;
+  cursor: pointer;
+
+  input[type="radio"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+  }
+`;
+
 export const FormActions = styled.div`
   display: flex;
   justify-content: flex-end;

--- a/src/pages/Course/Community/QuestionCreatePage/types.ts
+++ b/src/pages/Course/Community/QuestionCreatePage/types.ts
@@ -22,6 +22,8 @@ export interface QuestionFormData {
 	title: string;
 	content: string;
 	isAnonymous: boolean;
+	/** 익명일 때만: true면 별명, false면 표시명 "익명" */
+	anonymousUseNickname: boolean;
 	isPublic: boolean;
 	assignmentId: string;
 	problemId: string;

--- a/src/pages/Course/Community/QuestionDetailPage/components/QuestionDetailPageView.tsx
+++ b/src/pages/Course/Community/QuestionDetailPage/components/QuestionDetailPageView.tsx
@@ -144,6 +144,15 @@ export default function QuestionDetailPageView(
 							<span className="author">
 								{question.authorDisplayName ?? "익명"}
 							</span>
+							{question.isAuthor && <S.MyPostBadge>내 글</S.MyPostBadge>}
+							{d.isSectionStaff && question.authorRealNameForStaff ? (
+								<>
+									<span className="separator">·</span>
+									<S.StaffIdentityNote>
+										실명: {question.authorRealNameForStaff}
+									</S.StaffIdentityNote>
+								</>
+							) : null}
 							<span className="separator">·</span>
 							<span className="date">{formatDate(question.createdAt)}</span>
 							<span className="separator">·</span>
@@ -198,6 +207,9 @@ export default function QuestionDetailPageView(
 									aria-label="익명으로 작성"
 								/>
 								<span>익명으로 작성</span>
+								<span style={{ fontSize: 12, color: "#888", marginLeft: 8 }}>
+									(이 글에서 익명 1, 2… 순으로 표시)
+								</span>
 							</S.CommentOption>
 							<S.BtnSubmitComment
 								type="submit"
@@ -216,21 +228,24 @@ export default function QuestionDetailPageView(
 								</S.EmptyComments>
 							) : (
 								d.comments.map((comment) => (
-									<S.CommentCard
-										key={comment.id}
-										$accepted={comment.isAccepted}
-									>
+									<S.CommentCard key={comment.id}>
 										<S.CommentHeader>
 											<S.CommentAuthorInfo>
 												<S.CommentAuthor>
 													{comment.authorDisplayName ?? "익명"}
 												</S.CommentAuthor>
-												{comment.isInstructorAnswer && (
-													<S.BadgeInstructor>교수</S.BadgeInstructor>
+												{comment.isAuthor && (
+													<S.MyPostBadge>내 글</S.MyPostBadge>
 												)}
-												{comment.isAccepted && (
-													<S.BadgeAccepted>채택됨</S.BadgeAccepted>
-												)}
+												{d.isSectionStaff && comment.authorRealNameForStaff ? (
+													<S.StaffIdentityNote>
+														실명: {comment.authorRealNameForStaff}
+													</S.StaffIdentityNote>
+												) : null}
+												{comment.isInstructorAnswer &&
+													!comment.isAnonymous && (
+														<S.BadgeInstructor>교수/TA</S.BadgeInstructor>
+													)}
 											</S.CommentAuthorInfo>
 											<S.CommentDate>
 												{formatDate(comment.createdAt)}
@@ -261,28 +276,6 @@ export default function QuestionDetailPageView(
 												>
 													삭제
 												</S.BtnDeleteComment>
-											)}
-
-											{d.canManageAccept && (
-												<>
-													{!comment.isAccepted ? (
-														<S.BtnAccept
-															type="button"
-															onClick={() => d.handleAcceptComment(comment.id)}
-														>
-															채택하기
-														</S.BtnAccept>
-													) : (
-														<S.BtnUnaccept
-															type="button"
-															onClick={() =>
-																d.handleUnacceptComment(comment.id)
-															}
-														>
-															채택 해제
-														</S.BtnUnaccept>
-													)}
-												</>
 											)}
 										</S.CommentActions>
 									</S.CommentCard>

--- a/src/pages/Course/Community/QuestionDetailPage/hooks/useQuestionDetailPage.ts
+++ b/src/pages/Course/Community/QuestionDetailPage/hooks/useQuestionDetailPage.ts
@@ -101,7 +101,10 @@ export function useQuestionDetailPage() {
 		async (e: React.FormEvent) => {
 			e.preventDefault();
 			if (!questionId) return;
-			if (!commentContent.trim()) {
+			const tempDiv = document.createElement("div");
+			tempDiv.innerHTML = commentContent;
+			const text = tempDiv.textContent || tempDiv.innerText || "";
+			if (!text.trim()) {
 				alert("댓글 내용을 입력해주세요");
 				return;
 			}
@@ -132,38 +135,6 @@ export function useQuestionDetailPage() {
 		],
 	);
 
-	const handleAcceptComment = useCallback(
-		async (commentId: number) => {
-			if (!window.confirm("이 댓글을 채택하시겠습니까?")) return;
-			try {
-				await APIService.acceptComment(commentId);
-				alert("댓글이 채택되었습니다!");
-				fetchComments();
-				fetchQuestionDetail();
-			} catch (err) {
-				console.error("Error accepting comment:", err);
-				alert("채택 중 오류가 발생했습니다");
-			}
-		},
-		[fetchComments, fetchQuestionDetail],
-	);
-
-	const handleUnacceptComment = useCallback(
-		async (commentId: number) => {
-			if (!window.confirm("이 댓글의 채택을 해제하시겠습니까?")) return;
-			try {
-				await APIService.unacceptComment(commentId);
-				alert("채택이 해제되었습니다!");
-				fetchComments();
-				fetchQuestionDetail();
-			} catch (err) {
-				console.error("Error unaccepting comment:", err);
-				alert("채택 해제 중 오류가 발생했습니다");
-			}
-		},
-		[fetchComments, fetchQuestionDetail],
-	);
-
 	const handleDeleteComment = useCallback(
 		async (commentId: number) => {
 			if (!window.confirm("정말 이 댓글을 삭제하시겠습니까?")) return;
@@ -180,15 +151,15 @@ export function useQuestionDetailPage() {
 		[fetchComments, fetchQuestionDetail],
 	);
 
-	const isInstructor =
-		sectionInfo &&
-		auth?.user?.id &&
-		(auth.user.id === sectionInfo.instructorId ||
-			auth.user.id === sectionInfo.instructor?.id ||
-			auth.user.role === "ADMIN" ||
-			auth.user.role === "SUPER_ADMIN");
-
-	const canManageAccept = question && (question.isAuthor || isInstructor);
+	const isSectionStaff = Boolean(
+		sectionInfo?.isCurrentUserSectionStaff ||
+			auth?.user?.role === "ADMIN" ||
+			auth?.user?.role === "SUPER_ADMIN" ||
+			(auth?.user?.id &&
+				sectionInfo &&
+				(auth.user.id === sectionInfo.instructorId ||
+					auth.user.id === sectionInfo.instructor?.id)),
+	);
 
 	const handleResolveQuestion = useCallback(async () => {
 		if (!questionId) return;
@@ -232,12 +203,10 @@ export function useQuestionDetailPage() {
 		setCommentAnonymous,
 		submittingComment,
 		isSidebarCollapsed,
-		canManageAccept,
+		isSectionStaff,
 		handleLikeQuestion,
 		handleLikeComment,
 		handleSubmitComment,
-		handleAcceptComment,
-		handleUnacceptComment,
 		handleDeleteComment,
 		handleResolveQuestion,
 		handleDeleteQuestion,

--- a/src/pages/Course/Community/QuestionDetailPage/styles.ts
+++ b/src/pages/Course/Community/QuestionDetailPage/styles.ts
@@ -69,6 +69,25 @@ export const QuestionBadges = styled.div`
   flex-wrap: wrap;
 `;
 
+export const MyPostBadge = styled.span`
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  margin-left: 4px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  background: #e8edff;
+  color: #4c51bf;
+`;
+
+export const StaffIdentityNote = styled.span`
+  font-size: 12px;
+  color: #805ad5;
+  font-weight: 500;
+  margin-left: 4px;
+`;
+
 export const Badge = styled.span<{ $variant?: string }>`
   display: inline-flex;
   align-items: center;
@@ -400,11 +419,11 @@ export const EmptyComments = styled.div`
 `;
 
 /* 댓글 카드 */
-export const CommentCard = styled.div<{ $accepted?: boolean }>`
+export const CommentCard = styled.div`
   padding: 20px;
-  background: ${(props) => (props.$accepted ? "#e8f5e9" : "#f8f9fa")};
+  background: #f8f9fa;
   border-radius: 8px;
-  border: 2px solid ${(props) => (props.$accepted ? "#4caf50" : "transparent")};
+  border: 2px solid transparent;
   transition: all 0.2s;
 `;
 
@@ -419,6 +438,7 @@ export const CommentAuthorInfo = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 `;
 
 export const CommentAuthor = styled.span`

--- a/src/pages/Course/Community/QuestionDetailPage/types.ts
+++ b/src/pages/Course/Community/QuestionDetailPage/types.ts
@@ -6,6 +6,7 @@ export interface SectionInfo {
 	sectionNumber?: string;
 	instructorId?: number;
 	instructor?: { id: number };
+	isCurrentUserSectionStaff?: boolean;
 }
 
 export interface Question {
@@ -13,6 +14,8 @@ export interface Question {
 	title: string;
 	content: string;
 	authorDisplayName?: string;
+	authorId?: number | null;
+	authorRealNameForStaff?: string;
 	createdAt: string;
 	viewCount: number;
 	likeCount: number;
@@ -31,8 +34,11 @@ export interface Comment {
 	id: number;
 	content: string;
 	authorDisplayName?: string;
+	authorId?: number | null;
+	authorRealNameForStaff?: string;
 	createdAt: string;
 	likeCount: number;
+	isAnonymous?: boolean;
 	isAccepted?: boolean;
 	isAuthor?: boolean;
 	isInstructorAnswer?: boolean;

--- a/src/services/APIService.ts
+++ b/src/services/APIService.ts
@@ -1459,18 +1459,6 @@ class APIService {
 		});
 	}
 
-	async acceptComment(commentId: number | string): Promise<any> {
-		return await this.request(`/community/comments/${commentId}/accept`, {
-			method: "POST",
-		});
-	}
-
-	async unacceptComment(commentId: number | string): Promise<any> {
-		return await this.request(`/community/comments/${commentId}/accept`, {
-			method: "DELETE",
-		});
-	}
-
 	async deleteComment(commentId: number | string): Promise<any> {
 		return await this.request(`/community/comments/${commentId}`, {
 			method: "DELETE",


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #200 

## 📝작업 내용
## 요약
커뮤니티 UX·에디터·코드 페이지에서 언어/별명 UI 정리 및 스태프 표시.

## 변경 사항

### 커뮤니티
- 질문 작성: 익명 시 **무작위 별칭 / ‘익명’만** 라디오; **별명 입력·모달 제거** (서버 생성에 맞춤).
- 목록 `QuestionCard`: `내 글` 배지, 매니저에게 **실명** 보조 표시.
- 상세: 채택 UI/API 호출 제거; 질문·댓글 **내 글** 배지; 매니저 **실명** 표시.
- `useQuestionDetailPage`: `isSectionStaff` (`isCurrentUserSectionStaff` + 교수 id + ADMIN 등).
- `Comment` 타입에 `isAnonymous`.
- 익명일 때 **교수/TA 배지** 비표시 (`isInstructorAnswer && !isAnonymous`).

### API
- `acceptComment` / `unacceptComment` 메서드 제거 (`APIService.ts`).

### 코드 에디터 (과제·코딩 테스트 풀이)
- 헤더 **언어 `<select>`**(C 고정·비활성) 제거.
- `useProblemSolve` / `useCodingQuizSolve`에서 `handleLanguageChange` 제거.

### TipTap 에디터
- 코드 블록 옆 **「언어 선택」** 드롭다운 제거; 관련 상수·핸들러·CSS 정리.

### 타입
- `CourseCommunityPage` `SectionInfo`, `Question` 필드 확장 (`isAuthor`, `authorRealNameForStaff` 등).

## 테스트 제안
- [ ] 익명 질문 작성 후 목록/상세 표시명·내 글 배지
- [ ] TA 계정으로 실명 보조 문구 노출
- [ ] 익명 댓글 `익명 n` 순서
- [ ] 질문 작성 에디터 툴바에 언어 선택 없음
- [ ] 과제/코딩테스트 풀이 헤더에 언어 드롭다운 없음