### PR TITLE
fix/issue-202/editor UI개선 및 과제 간 이동 및 필터

### DIFF
--- a/src/pages/AssignmentPage/ProblemSolvePage/components/AssignmentSelectModal/index.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/components/AssignmentSelectModal/index.tsx
@@ -1,0 +1,62 @@
+import type React from "react";
+import * as M from "../../../../Course/CodingQuiz/CodingQuizSolvePage/ProblemSelectModal/styles";
+
+interface AssignmentItem {
+	id: number;
+	title: string;
+}
+
+interface AssignmentSelectModalProps {
+	isOpen: boolean;
+	assignments: AssignmentItem[];
+	currentAssignmentId: number | null;
+	isChanging?: boolean;
+	onClose: () => void;
+	onSelectAssignment: (assignmentId: number) => void;
+}
+
+const AssignmentSelectModal: React.FC<AssignmentSelectModalProps> = ({
+	isOpen,
+	assignments,
+	currentAssignmentId,
+	isChanging = false,
+	onClose,
+	onSelectAssignment,
+}) => {
+	if (!isOpen) return null;
+
+	const handleBackdropClick = (e: React.MouseEvent) => {
+		if (e.target === e.currentTarget) onClose();
+	};
+
+	return (
+		<M.Backdrop onClick={handleBackdropClick}>
+			<M.Modal onClick={(e) => e.stopPropagation()}>
+				<M.Header>
+					<M.Title>과제 이동</M.Title>
+					<M.CloseButton onClick={onClose}>✕</M.CloseButton>
+				</M.Header>
+				<M.Notice>
+					선택한 과제의 첫 번째 문제로 이동합니다. 저장되지 않은 코드가 있으면
+					확인합니다.
+				</M.Notice>
+				<M.ProblemList>
+					{assignments.map((a, index) => (
+						<M.ProblemItem
+							key={a.id}
+							$active={a.id === currentAssignmentId}
+							onClick={() => {
+								if (!isChanging) onSelectAssignment(a.id);
+							}}
+						>
+							<M.ProblemNumber>과제 {index + 1}</M.ProblemNumber>
+							<M.ProblemTitle>{a.title}</M.ProblemTitle>
+						</M.ProblemItem>
+					))}
+				</M.ProblemList>
+			</M.Modal>
+		</M.Backdrop>
+	);
+};
+
+export default AssignmentSelectModal;

--- a/src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx
@@ -7,6 +7,8 @@ import ProblemDescription from "../../../Course/CodingQuiz/CodingQuizSolvePage/P
 import CodeEditor from "../../../Course/CodingQuiz/CodingQuizSolvePage/CodeEditor";
 import ExecutionResult from "../../../Course/CodingQuiz/CodingQuizSolvePage/ExecutionResult";
 import DraggablePanel from "../../../Course/CodingQuiz/CodingQuizSolvePage/DraggablePanel";
+import ProblemSelectModal from "../../../Course/CodingQuiz/CodingQuizSolvePage/ProblemSelectModal";
+import AssignmentSelectModal from "./AssignmentSelectModal";
 import type { PanelKey } from "../hooks/useProblemSolve";
 import type { Problem } from "../types";
 import * as S from "../styles";
@@ -36,7 +38,21 @@ interface ProblemSolveViewProps {
 	horizontalSizes: number[];
 	verticalSizes: number[];
 	panelLayout: { left: PanelKey; topRight: PanelKey; bottomRight: PanelKey };
+	problems: Array<{ id: number; title: string; order: number }>;
+	isProblemModalOpen: boolean;
+	isProblemChanging: boolean;
+	setIsProblemModalOpen: (open: boolean) => void;
 	handlePanelMove: (dragged: string, target: string) => void;
+	handleProblemChange: (problemId: number) => void;
+	problemNav: {
+		prevProblemId: number | null;
+		nextProblemId: number | null;
+		indexLabel: string;
+	};
+	sectionAssignments: Array<{ id: number; title: string }>;
+	isAssignmentModalOpen: boolean;
+	setIsAssignmentModalOpen: (open: boolean) => void;
+	handleSelectOtherAssignment: (assignmentId: number) => void;
 	handleSubmit: () => void;
 	handleSubmitWithOutput: () => void;
 	saveToSession: () => void;
@@ -52,6 +68,10 @@ interface ProblemSolveViewProps {
 	isDeadlinePassed: boolean;
 	isAssignmentActive: boolean;
 	userRole: string | null;
+	showUnsavedModal: boolean;
+	handleUnsavedModalSave: () => void;
+	handleUnsavedModalSkip: () => void;
+	handleUnsavedModalCancel: () => void;
 }
 
 const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
@@ -75,7 +95,17 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 		horizontalSizes,
 		verticalSizes,
 		panelLayout,
+		problems,
+		isProblemModalOpen,
+		isProblemChanging,
+		setIsProblemModalOpen,
 		handlePanelMove,
+		handleProblemChange,
+		problemNav,
+		sectionAssignments,
+		isAssignmentModalOpen,
+		setIsAssignmentModalOpen,
+		handleSelectOtherAssignment,
 		handleSubmit,
 		handleSubmitWithOutput,
 		saveToSession,
@@ -87,6 +117,10 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 		isDeadlinePassed,
 		isAssignmentActive,
 		userRole,
+		showUnsavedModal,
+		handleUnsavedModalSave,
+		handleUnsavedModalSkip,
+		handleUnsavedModalCancel,
 	} = props;
 	const navigate = useNavigate();
 
@@ -155,29 +189,78 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 					</S.SaveModal>
 				)}
 				<S.Header $theme={theme}>
-					<S.Breadcrumb>
-						<S.BreadcrumbLink
-							type="button"
-							onClick={() => navigate(`/sections/${sectionId}/dashboard`)}
-						>
-							{sectionInfo.courseTitle}
-						</S.BreadcrumbLink>
-						<span> › </span>
-						<S.BreadcrumbLink
-							type="button"
-							onClick={() =>
-								navigate(
-									`/sections/${sectionId}/course-assignments?assignmentId=${assignmentId}`,
-								)
-							}
-						>
-							{assignmentInfo.title}
-						</S.BreadcrumbLink>
-						<span> › </span>
-						<S.BreadcrumbCurrent $theme={theme}>
-							{currentProblem.title}
-						</S.BreadcrumbCurrent>
-					</S.Breadcrumb>
+					<S.HeaderMain>
+						<S.Breadcrumb>
+							<S.BreadcrumbLink
+								type="button"
+								onClick={() => navigate(`/sections/${sectionId}/dashboard`)}
+							>
+								{sectionInfo.courseTitle}
+							</S.BreadcrumbLink>
+							<span> › </span>
+							<S.BreadcrumbLink
+								type="button"
+								onClick={() =>
+									navigate(
+										`/sections/${sectionId}/course-assignments?assignmentId=${assignmentId}`,
+									)
+								}
+							>
+								{assignmentInfo.title}
+							</S.BreadcrumbLink>
+							<span> › </span>
+							<S.BreadcrumbCurrent $theme={theme}>
+								{currentProblem.title}
+							</S.BreadcrumbCurrent>
+						</S.Breadcrumb>
+						<S.ProblemToolbarRow>
+							<S.PrevNextButton
+								type="button"
+								$theme={theme}
+								$disabled={problemNav.prevProblemId == null || isProblemChanging}
+								disabled={problemNav.prevProblemId == null || isProblemChanging}
+								onClick={() => {
+									if (problemNav.prevProblemId != null) {
+										handleProblemChange(problemNav.prevProblemId);
+									}
+								}}
+							>
+								‹ 이전 문제
+							</S.PrevNextButton>
+							{problemNav.indexLabel ? (
+								<S.ProblemIndexHint $theme={theme}>
+									문제 {problemNav.indexLabel}
+								</S.ProblemIndexHint>
+							) : null}
+							<S.PrevNextButton
+								type="button"
+								$theme={theme}
+								$disabled={problemNav.nextProblemId == null || isProblemChanging}
+								disabled={problemNav.nextProblemId == null || isProblemChanging}
+								onClick={() => {
+									if (problemNav.nextProblemId != null) {
+										handleProblemChange(problemNav.nextProblemId);
+									}
+								}}
+							>
+								다음 문제 ›
+							</S.PrevNextButton>
+							<S.ProblemNavigateButton
+								type="button"
+								$theme={theme}
+								onClick={() => setIsProblemModalOpen(true)}
+							>
+								문제 목록
+							</S.ProblemNavigateButton>
+							<S.ProblemNavigateButton
+								type="button"
+								$theme={theme}
+								onClick={() => setIsAssignmentModalOpen(true)}
+							>
+								과제 이동
+							</S.ProblemNavigateButton>
+						</S.ProblemToolbarRow>
+					</S.HeaderMain>
 					<S.Controls>
 						<S.ThemeButton
 							type="button"
@@ -227,6 +310,61 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 						</Split>
 					</Split>
 				</S.MainSplit>
+				<ProblemSelectModal
+					isOpen={isProblemModalOpen}
+					problems={problems}
+					currentProblemId={currentProblem.id ?? null}
+					isChanging={isProblemChanging}
+					onClose={() => setIsProblemModalOpen(false)}
+					onSelectProblem={(pid) => {
+						handleProblemChange(pid);
+					}}
+				/>
+				<AssignmentSelectModal
+					isOpen={isAssignmentModalOpen}
+					assignments={sectionAssignments}
+					currentAssignmentId={
+						assignmentId != null ? Number(assignmentId) : null
+					}
+					isChanging={isProblemChanging}
+					onClose={() => setIsAssignmentModalOpen(false)}
+					onSelectAssignment={handleSelectOtherAssignment}
+				/>
+				{showUnsavedModal && (
+					<S.UnsavedModalOverlay>
+						<S.UnsavedModalCard $theme={theme}>
+							<S.UnsavedModalTitle $theme={theme}>
+								저장되지 않은 변경사항이 있습니다
+							</S.UnsavedModalTitle>
+							<S.UnsavedModalDesc $theme={theme}>
+								문제를 이동하기 전에 변경사항을 저장하시겠습니까?
+							</S.UnsavedModalDesc>
+							<S.UnsavedModalActions>
+								<S.UnsavedModalButton
+									type="button"
+									$theme={theme}
+									onClick={handleUnsavedModalCancel}
+								>
+									취소
+								</S.UnsavedModalButton>
+								<S.UnsavedModalButton
+									type="button"
+									$theme={theme}
+									onClick={handleUnsavedModalSkip}
+								>
+									저장 안 함
+								</S.UnsavedModalButton>
+								<S.UnsavedModalPrimaryButton
+									type="button"
+									$theme={theme}
+									onClick={handleUnsavedModalSave}
+								>
+									저장 후 이동
+								</S.UnsavedModalPrimaryButton>
+							</S.UnsavedModalActions>
+						</S.UnsavedModalCard>
+					</S.UnsavedModalOverlay>
+				)}
 			</S.PageWrapper>
 		</DndProvider>
 	);

--- a/src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts
+++ b/src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import { authState } from "../../../../recoil/atoms";
@@ -19,6 +19,9 @@ export type PanelLayout = {
 };
 type SessionSaveStatus = "idle" | "saving" | "saved" | "error";
 type CodeLoadSource = "session" | "backend" | "default" | null;
+type AssignmentProblemSummary = { id: number; title: string; order: number };
+type SectionAssignmentSummary = { id: number; title: string };
+type PendingNavigation = { assignmentId: string; problemId: number };
 
 export function useProblemSolve() {
 	const { assignmentId, problemId, sectionId } = useParams<{
@@ -63,8 +66,8 @@ export function useProblemSolve() {
 	const [isDeadlinePassed, setIsDeadlinePassed] = useState(false);
 	const [isAssignmentActive, setIsAssignmentActive] = useState(true);
 	const navigate = useNavigate();
-	const [horizontalSizes, setHorizontalSizes] = useState([40, 60]);
-	const [verticalSizes, setVerticalSizes] = useState([70, 30]);
+	const [horizontalSizes, setHorizontalSizes] = useState([28, 72]);
+	const [verticalSizes, setVerticalSizes] = useState([82, 18]);
 	const [panelLayout, setPanelLayout] = useState<PanelLayout>({
 		left: "description",
 		topRight: "editor",
@@ -76,12 +79,21 @@ export function useProblemSolve() {
 	const [codeLoadSource, setCodeLoadSource] = useState<CodeLoadSource>(null);
 	const [sessionCleared, setSessionCleared] = useState(false);
 	const [userRole, setUserRole] = useState<string | null>(null);
+	const [problems, setProblems] = useState<AssignmentProblemSummary[]>([]);
+	const [isProblemModalOpen, setIsProblemModalOpen] = useState(false);
+	const [isAssignmentModalOpen, setIsAssignmentModalOpen] = useState(false);
+	const [isProblemChanging, setIsProblemChanging] = useState(false);
+	const [sectionAssignments, setSectionAssignments] = useState<
+		SectionAssignmentSummary[]
+	>([]);
 	const auth = useRecoilValue(authState);
 
 	// 마지막으로 서버에 저장된 코드 (hasUnsavedChanges 판단 기준)
 	const lastSavedCodeRef = useRef<string>("");
 	// IndexedDB 디바운스 저장 타이머
 	const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [showUnsavedModal, setShowUnsavedModal] = useState(false);
+	const pendingNavigationRef = useRef<PendingNavigation | null>(null);
 
 	useEffect(() => {
 		const loadAllInfo = async () => {
@@ -101,18 +113,34 @@ export function useProblemSolve() {
 					// 역할 확인 실패해도 계속 진행
 				}
 
-				const [problemInfo, sectionInfoRes, assignmentInfoRes] =
+				const [problemInfo, sectionInfoRes, assignmentInfoRes, assignmentProblemsRes] =
 					await Promise.all([
 						apiService.getProblemInfo(problemId),
 						apiService.getSectionInfo(sectionId),
 						apiService.getAssignmentInfoBySection(sectionId, assignmentId),
+						apiService.getAssignmentProblems(sectionId, assignmentId),
 					]);
 				const problemData = problemInfo?.data ?? problemInfo;
 				const sectionData = sectionInfoRes?.data ?? sectionInfoRes;
 				const assignmentData = assignmentInfoRes?.data ?? assignmentInfoRes;
+				const assignmentProblemsRaw =
+					(assignmentProblemsRes as { problems?: unknown[] })?.problems ??
+					(assignmentProblemsRes as { data?: unknown[] })?.data ??
+					(Array.isArray(assignmentProblemsRes) ? assignmentProblemsRes : []);
+				const assignmentProblems: AssignmentProblemSummary[] = (
+					assignmentProblemsRaw as Array<Record<string, unknown>>
+				)
+					.map((p, idx) => ({
+						id: Number(p.id ?? p.problemId),
+						title: String(p.title ?? p.problemTitle ?? `문제 ${idx + 1}`),
+						order: Number(p.order ?? p.problemOrder ?? idx + 1),
+					}))
+					.filter((p) => Number.isFinite(p.id))
+					.sort((a, b) => a.order - b.order);
 				setCurrentProblem(problemData as Problem);
 				setSectionInfo(sectionData);
 				setAssignmentInfo(assignmentData);
+				setProblems(assignmentProblems);
 
 				// 과제 비활성화 체크 및 리다이렉트
 				const active = assignmentData?.active ?? true;
@@ -162,6 +190,31 @@ export function useProblemSolve() {
 		};
 		loadAllInfo();
 	}, [problemId, sectionId, assignmentId, navigate, auth.loading]);
+
+	useEffect(() => {
+		if (!sectionId || auth.loading) return;
+		let cancelled = false;
+		(async () => {
+			try {
+				const res = await apiService.getAssignmentsBySection(sectionId);
+				const raw = (res as { data?: unknown })?.data ?? res ?? [];
+				const arr = Array.isArray(raw) ? raw : [];
+				const list: SectionAssignmentSummary[] = arr
+					.map((a: Record<string, unknown>, idx: number) => ({
+						id: Number(a.id),
+						title: String(a.title ?? `과제 ${idx + 1}`),
+					}))
+					.filter((x) => Number.isFinite(x.id))
+					.sort((a, b) => a.id - b.id);
+				if (!cancelled) setSectionAssignments(list);
+			} catch {
+				if (!cancelled) setSectionAssignments([]);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, [sectionId, auth.loading]);
 
 	useEffect(() => {
 		const initializeSession = async () => {
@@ -579,6 +632,136 @@ export function useProblemSolve() {
 		setVerticalSizes(sizes);
 	}, []);
 
+	const doNavigateToProblem = useCallback(
+		(targetAssignmentId: string, targetProblemId: number) => {
+			if (!sectionId) return;
+			setIsProblemChanging(true);
+			navigate(
+				`/sections/${sectionId}/assignments/${targetAssignmentId}/detail/problems/${targetProblemId}`,
+			);
+			setTimeout(() => setIsProblemChanging(false), 150);
+		},
+		[sectionId, navigate],
+	);
+
+	const requestNavigateToProblem = useCallback(
+		(targetAssignmentId: string, targetProblemId: number) => {
+			if (!assignmentId || isProblemChanging) return;
+			if (
+				targetAssignmentId === assignmentId &&
+				targetProblemId === Number(problemId)
+			)
+				return;
+			const hasUnsaved =
+				code !== lastSavedCodeRef.current && code !== getDefaultCode(language);
+			if (hasUnsaved) {
+				pendingNavigationRef.current = {
+					assignmentId: targetAssignmentId,
+					problemId: targetProblemId,
+				};
+				setShowUnsavedModal(true);
+				return;
+			}
+			doNavigateToProblem(targetAssignmentId, targetProblemId);
+		},
+		[
+			assignmentId,
+			problemId,
+			isProblemChanging,
+			code,
+			language,
+			doNavigateToProblem,
+		],
+	);
+
+	const handleProblemChange = useCallback(
+		(problemIdToMove: number) => {
+			if (!assignmentId) return;
+			requestNavigateToProblem(assignmentId, problemIdToMove);
+		},
+		[assignmentId, requestNavigateToProblem],
+	);
+
+	const handleSelectOtherAssignment = useCallback(
+		async (targetAssignmentId: number) => {
+			if (!sectionId || !assignmentId) return;
+			if (Number(targetAssignmentId) === Number(assignmentId)) {
+				setIsAssignmentModalOpen(false);
+				return;
+			}
+			try {
+				const res = await apiService.getAssignmentProblems(
+					sectionId,
+					String(targetAssignmentId),
+				);
+				const raw =
+					(res as { problems?: unknown[] })?.problems ??
+					(res as { data?: unknown[] })?.data ??
+					(Array.isArray(res) ? res : []);
+				const arr = Array.isArray(raw) ? raw : [];
+				const mapped = arr
+					.map((p: Record<string, unknown>, idx: number) => ({
+						id: Number(p.id ?? p.problemId),
+						order: Number(p.order ?? p.problemOrder ?? idx + 1),
+					}))
+					.filter((p) => Number.isFinite(p.id))
+					.sort((a, b) => a.order - b.order);
+				if (mapped.length === 0) {
+					alert("이 과제에 등록된 문제가 없습니다.");
+					return;
+				}
+				const firstId = mapped[0].id;
+				setIsAssignmentModalOpen(false);
+				requestNavigateToProblem(String(targetAssignmentId), firstId);
+			} catch {
+				alert("과제 문제 목록을 불러오지 못했습니다.");
+			}
+		},
+		[sectionId, assignmentId, requestNavigateToProblem],
+	);
+
+	const problemNav = useMemo(() => {
+		const cid = problemId ? Number(problemId) : NaN;
+		const idx = problems.findIndex((p) => p.id === cid);
+		if (idx < 0 || problems.length === 0) {
+			return {
+				prevProblemId: null as number | null,
+				nextProblemId: null as number | null,
+				indexLabel: "",
+			};
+		}
+		return {
+			prevProblemId: idx > 0 ? problems[idx - 1].id : null,
+			nextProblemId:
+				idx < problems.length - 1 ? problems[idx + 1].id : null,
+			indexLabel: `${idx + 1} / ${problems.length}`,
+		};
+	}, [problems, problemId]);
+
+	const handleUnsavedModalSave = useCallback(async () => {
+		setShowUnsavedModal(false);
+		await saveToBackend(false);
+		const pending = pendingNavigationRef.current;
+		pendingNavigationRef.current = null;
+		if (pending != null) {
+			doNavigateToProblem(pending.assignmentId, pending.problemId);
+		}
+	}, [saveToBackend, doNavigateToProblem]);
+
+	const handleUnsavedModalSkip = useCallback(() => {
+		setShowUnsavedModal(false);
+		const pending = pendingNavigationRef.current;
+		pendingNavigationRef.current = null;
+		if (pending != null) {
+			doNavigateToProblem(pending.assignmentId, pending.problemId);
+		}
+	}, [doNavigateToProblem]);
+
+	const handleUnsavedModalCancel = useCallback(() => {
+		setShowUnsavedModal(false);
+		pendingNavigationRef.current = null;
+	}, []);
+
 	const gutterStyleCallback = useCallback(
 		(_dim: "width" | "height", _gutterSize: number, _index: number) => ({
 			backgroundColor: theme === "dark" ? "#2d3748" : "#cbd5e0",
@@ -614,7 +797,17 @@ export function useProblemSolve() {
 		horizontalSizes,
 		verticalSizes,
 		panelLayout,
+		problems,
+		isProblemModalOpen,
+		isProblemChanging,
+		setIsProblemModalOpen,
 		handlePanelMove,
+		handleProblemChange,
+		problemNav,
+		sectionAssignments,
+		isAssignmentModalOpen,
+		setIsAssignmentModalOpen,
+		handleSelectOtherAssignment,
 		handleSubmit,
 		handleSubmitWithOutput,
 		saveToSession,
@@ -627,5 +820,9 @@ export function useProblemSolve() {
 		isAssignmentActive,
 		userRole,
 		hasUnsavedChanges,
+		showUnsavedModal,
+		handleUnsavedModalSave,
+		handleUnsavedModalSkip,
+		handleUnsavedModalCancel,
 	};
 }

--- a/src/pages/AssignmentPage/ProblemSolvePage/index.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/index.tsx
@@ -41,7 +41,17 @@ const ProblemSolvePage: React.FC = () => {
 			horizontalSizes={hook.horizontalSizes}
 			verticalSizes={hook.verticalSizes}
 			panelLayout={hook.panelLayout}
+			problems={hook.problems}
+			isProblemModalOpen={hook.isProblemModalOpen}
+			isProblemChanging={hook.isProblemChanging}
+			setIsProblemModalOpen={hook.setIsProblemModalOpen}
 			handlePanelMove={hook.handlePanelMove}
+			handleProblemChange={hook.handleProblemChange}
+			problemNav={hook.problemNav}
+			sectionAssignments={hook.sectionAssignments}
+			isAssignmentModalOpen={hook.isAssignmentModalOpen}
+			setIsAssignmentModalOpen={hook.setIsAssignmentModalOpen}
+			handleSelectOtherAssignment={hook.handleSelectOtherAssignment}
 			handleSubmit={hook.handleSubmit}
 			handleSubmitWithOutput={hook.handleSubmitWithOutput}
 			saveToSession={hook.saveToSession}
@@ -53,6 +63,10 @@ const ProblemSolvePage: React.FC = () => {
 			isDeadlinePassed={hook.isDeadlinePassed}
 			isAssignmentActive={hook.isAssignmentActive}
 			userRole={hook.userRole}
+			showUnsavedModal={hook.showUnsavedModal}
+			handleUnsavedModalSave={hook.handleUnsavedModalSave}
+			handleUnsavedModalSkip={hook.handleUnsavedModalSkip}
+			handleUnsavedModalCancel={hook.handleUnsavedModalCancel}
 		/>
 	);
 };

--- a/src/pages/AssignmentPage/ProblemSolvePage/styles.ts
+++ b/src/pages/AssignmentPage/ProblemSolvePage/styles.ts
@@ -133,7 +133,53 @@ export const Header = styled.div<{ $theme: "light" | "dark" }>`
 	background-color: ${(p) => (p.$theme === "light" ? "#ffffff" : "#161b22")};
 	display: flex;
 	justify-content: space-between;
+	align-items: flex-start;
+	gap: 16px;
+`;
+
+export const HeaderMain = styled.div`
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	min-width: 0;
+	flex: 1;
+`;
+
+export const ProblemToolbarRow = styled.div`
+	display: flex;
 	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+`;
+
+export const ProblemIndexHint = styled.span<{ $theme: "light" | "dark" }>`
+	font-size: 12px;
+	font-weight: 600;
+	color: ${(p) => (p.$theme === "light" ? "#57606a" : "#9aa4af")};
+	padding: 0 4px;
+`;
+
+export const PrevNextButton = styled.button<{
+	$theme: "light" | "dark";
+	$disabled?: boolean;
+}>`
+	padding: 6px 12px;
+	border-radius: 6px;
+	border: 1px solid ${(p) => (p.$theme === "light" ? "#e1e4e8" : "#30363d")};
+	background-color: ${(p) => (p.$theme === "light" ? "#f6f8fa" : "#21262d")};
+	color: ${(p) => (p.$theme === "light" ? "#24292e" : "#c9d1d9")};
+	font-size: 12px;
+	font-weight: 600;
+	cursor: ${(p) => (p.$disabled ? "not-allowed" : "pointer")};
+	opacity: ${(p) => (p.$disabled ? 0.45 : 1)};
+	white-space: nowrap;
+	transition: border-color 0.2s, background-color 0.2s;
+
+	&:hover:not(:disabled) {
+		border-color: ${(p) => (p.$theme === "light" ? "#0969da" : "#58a6ff")};
+		background-color: ${(p) =>
+			p.$theme === "light" ? "rgba(9, 105, 218, 0.08)" : "rgba(88, 166, 255, 0.12)"};
+	}
 `;
 
 export const Breadcrumb = styled.div`
@@ -240,4 +286,86 @@ export const SaveModalIcon = styled.span`
 
 export const SaveModalText = styled.span`
 	font-size: 16px;
+`;
+
+export const ProblemNavigateButton = styled.button<{ $theme: "light" | "dark" }>`
+	padding: 6px 12px;
+	border-radius: 6px;
+	border: 1px solid ${(p) => (p.$theme === "light" ? "#e1e4e8" : "#30363d")};
+	background-color: ${(p) => (p.$theme === "light" ? "#ffffff" : "#21262d")};
+	color: ${(p) => (p.$theme === "light" ? "#24292e" : "#c9d1d9")};
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+	white-space: nowrap;
+	transition: all 0.2s;
+
+	&:hover {
+		border-color: ${(p) => (p.$theme === "light" ? "#0969da" : "#58a6ff")};
+		background-color: ${(p) =>
+			p.$theme === "light" ? "rgba(9, 105, 218, 0.1)" : "rgba(88, 166, 255, 0.15)"};
+		color: ${(p) => (p.$theme === "light" ? "#0969da" : "#58a6ff")};
+	}
+`;
+
+export const UnsavedModalOverlay = styled.div`
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.45);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 10001;
+`;
+
+export const UnsavedModalCard = styled.div<{ $theme: "light" | "dark" }>`
+	width: min(92vw, 430px);
+	padding: 20px;
+	border-radius: 10px;
+	border: 1px solid ${(p) => (p.$theme === "light" ? "#d0d7de" : "#30363d")};
+	background: ${(p) => (p.$theme === "light" ? "#ffffff" : "#161b22")};
+	box-shadow: 0 14px 40px rgba(0, 0, 0, 0.35);
+`;
+
+export const UnsavedModalTitle = styled.h3<{ $theme: "light" | "dark" }>`
+	margin: 0 0 10px;
+	font-size: 17px;
+	color: ${(p) => (p.$theme === "light" ? "#24292e" : "#e6edf3")};
+`;
+
+export const UnsavedModalDesc = styled.p<{ $theme: "light" | "dark" }>`
+	margin: 0;
+	font-size: 14px;
+	line-height: 1.5;
+	color: ${(p) => (p.$theme === "light" ? "#57606a" : "#9aa4af")};
+`;
+
+export const UnsavedModalActions = styled.div`
+	margin-top: 18px;
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	flex-wrap: wrap;
+`;
+
+export const UnsavedModalButton = styled.button<{ $theme: "light" | "dark" }>`
+	padding: 7px 12px;
+	border-radius: 6px;
+	border: 1px solid ${(p) => (p.$theme === "light" ? "#d0d7de" : "#30363d")};
+	background: ${(p) => (p.$theme === "light" ? "#f6f8fa" : "#21262d")};
+	color: ${(p) => (p.$theme === "light" ? "#24292f" : "#c9d1d9")};
+	cursor: pointer;
+	font-size: 13px;
+`;
+
+export const UnsavedModalPrimaryButton = styled.button<{
+	$theme: "light" | "dark";
+}>`
+	padding: 7px 12px;
+	border-radius: 6px;
+	border: 1px solid #2f81f7;
+	background: #2f81f7;
+	color: #ffffff;
+	cursor: pointer;
+	font-size: 13px;
 `;

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/components/CourseAssignmentsPageView.tsx
@@ -37,7 +37,9 @@ export default function CourseAssignmentsPageView(
 				<S.Content $isCollapsed={d.isSidebarCollapsed}>
 					<S.ErrorMessage>
 						<p>{d.error}</p>
-						<button onClick={d.fetchAssignmentsData}>다시 시도</button>
+						<button type="button" onClick={d.fetchAssignmentsData}>
+							다시 시도
+						</button>
 					</S.ErrorMessage>
 				</S.Content>
 			</S.Container>
@@ -70,13 +72,25 @@ export default function CourseAssignmentsPageView(
 						<S.AssignmentsTitle>과제</S.AssignmentsTitle>
 						<S.AssignmentsSummary>
 							과제 {d.assignments.length} · 문제{" "}
-							{d.assignments.reduce((sum, a) => sum + a.totalProblems, 0)}
+							{d.assignments.reduce((sum, a) => sum + a.totalProblems, 0)} · 기본: 최근 추가순
 						</S.AssignmentsSummary>
+						<S.SortSelect
+							value={d.assignmentSort}
+							onChange={(e) =>
+								d.setAssignmentSort(
+									e.target.value as "recentFirst" | "oldestFirst" | "unsolvedFirst",
+								)
+							}
+						>
+							<option value="recentFirst">최근 추가순</option>
+							<option value="oldestFirst">오래된 과제순</option>
+							<option value="unsolvedFirst">미해결 문제 많은순</option>
+						</S.SortSelect>
 					</S.AssignmentsHeader>
 
 					<S.AssignmentsAccordion>
-						{d.assignments.length > 0 ? (
-							d.assignments.map((assignment, index) => (
+						{d.sortedAssignments.length > 0 ? (
+							d.sortedAssignments.map((assignment, index) => (
 								<S.AccordionItem 
 									key={assignment.id}
 									$inactive={d.isManager && assignment.active === false}
@@ -144,26 +158,10 @@ export default function CourseAssignmentsPageView(
 											<S.AccordionProblemsSection>
 												<S.ProblemsSectionRow>
 													<S.ProblemsSubtitle>문제</S.ProblemsSubtitle>
-													{assignment.problems && assignment.problems.length > 0 && (
-														<S.ProblemSortRow>
-															<S.ProblemSortSelect
-																value={d.problemSortByAssignmentId?.[assignment.id] ?? "original"}
-																onChange={(e) => {
-																	const v = e.target.value as "original" | "solvedFirst" | "unsolvedFirst";
-																	d.setProblemSortForAssignment?.(assignment.id, v);
-																}}
-																onClick={(e) => e.stopPropagation()}
-															>
-																<option value="original">기본</option>
-																<option value="unsolvedFirst">미해결 문제</option>
-																<option value="solvedFirst">해결 문제</option>
-															</S.ProblemSortSelect>
-														</S.ProblemSortRow>
-													)}
 												</S.ProblemsSectionRow>
 												{assignment.problems && assignment.problems.length > 0 ? (
 													<S.AccordionProblemsList>
-														{(d.getSortedProblems?.(assignment) ?? assignment.problems).map((problem) => {
+														{assignment.problems.map((problem) => {
 															const badgeType =
 																problem.status === "ACCEPTED"
 																	? problem.isOnTime === false

--- a/src/pages/Course/Assignments/CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts
+++ b/src/pages/Course/Assignments/CourseAssignmentsPage/hooks/useCourseAssignmentsPage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useRecoilValue, useRecoilState } from "recoil";
 import { authState, sidebarCollapsedState } from "../../../../../recoil/atoms";
@@ -28,13 +28,12 @@ export function useCourseAssignmentsPage() {
 	const [error, setError] = useState<string | null>(null);
 	const [sectionInfo, setSectionInfo] = useState<SectionInfo | null>(null);
 	const [assignments, setAssignments] = useState<Assignment[]>([]);
+	const [assignmentSort, setAssignmentSort] = useState<
+		"recentFirst" | "oldestFirst" | "unsolvedFirst"
+	>("recentFirst");
 	const [expandedAssignmentIds, setExpandedAssignmentIds] = useState<number[]>(
 		[],
 	);
-	/** 과제별 문제 목록 정렬: 기본(원래 순서) / 미해결 문제 / 해결 문제 (과제 id -> 정렬 방식) */
-	const [problemSortByAssignmentId, setProblemSortByAssignmentId] = useState<
-		Record<number, "original" | "solvedFirst" | "unsolvedFirst">
-	>({});
 	const [userRole, setUserRole] = useState<string | null>(null);
 	const [isManager, setIsManager] = useState(false);
 	/** 알림 등에서 assignmentId 쿼리로 진입 시 한 번만 펼치기 위해 적용한 URL 값 (접은 뒤 다시 펼쳐지지 않도록) */
@@ -244,34 +243,6 @@ export function useCourseAssignmentsPage() {
 		);
 	}, []);
 
-	/** 해당 과제의 문제 목록을 현재 정렬 설정에 따라 정렬 (기본: 원래 순서) */
-	const getSortedProblems = useCallback(
-		(assignment: Assignment) => {
-			const sort = problemSortByAssignmentId[assignment.id] ?? "original";
-			const list = [...(assignment.problems ?? [])];
-			if (sort === "original") return list;
-			const order = (p: Assignment["problems"][0]) =>
-				p.status === "ACCEPTED" ? 2 : p.status === "SUBMITTED" ? 1 : 0;
-			if (sort === "solvedFirst") {
-				list.sort((a, b) => order(b) - order(a));
-			} else {
-				list.sort((a, b) => order(a) - order(b));
-			}
-			return list;
-		},
-		[problemSortByAssignmentId],
-	);
-
-	const setProblemSortForAssignment = useCallback(
-		(assignmentId: number, value: "original" | "solvedFirst" | "unsolvedFirst") => {
-			setProblemSortByAssignmentId((prev) => ({
-				...prev,
-				[assignmentId]: value,
-			}));
-		},
-		[],
-	);
-
 	const formatDate = useCallback((dateString: string): string => {
 		if (!dateString) return "";
 		const date = new Date(dateString);
@@ -349,6 +320,31 @@ export function useCourseAssignmentsPage() {
 		setIsSidebarCollapsed((prev) => !prev);
 	}, [setIsSidebarCollapsed]);
 
+	const sortedAssignments = useMemo(() => {
+		const list = [...assignments];
+		const createdKey = (a: Assignment) => {
+			const createdAt = (a as { createdAt?: string }).createdAt;
+			const t = createdAt ? new Date(createdAt).getTime() : Number.NaN;
+			return Number.isNaN(t) ? a.id : t;
+		};
+
+		if (assignmentSort === "oldestFirst") {
+			list.sort((a, b) => createdKey(a) - createdKey(b));
+			return list;
+		}
+		if (assignmentSort === "unsolvedFirst") {
+			list.sort((a, b) => {
+				const unsolvedA = Math.max(0, a.totalProblems - a.submittedProblems);
+				const unsolvedB = Math.max(0, b.totalProblems - b.submittedProblems);
+				if (unsolvedB !== unsolvedA) return unsolvedB - unsolvedA;
+				return createdKey(b) - createdKey(a);
+			});
+			return list;
+		}
+		list.sort((a, b) => createdKey(b) - createdKey(a));
+		return list;
+	}, [assignments, assignmentSort]);
+
 	return {
 		sectionId,
 		activeMenu,
@@ -357,9 +353,9 @@ export function useCourseAssignmentsPage() {
 		isSidebarCollapsed,
 		sectionInfo,
 		assignments,
-		getSortedProblems,
-		problemSortByAssignmentId,
-		setProblemSortForAssignment,
+		sortedAssignments,
+		assignmentSort,
+		setAssignmentSort,
 		expandedAssignmentIds,
 		userRole,
 		isManager,

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/CodeEditor/index.tsx
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/CodeEditor/index.tsx
@@ -9,8 +9,100 @@ import { linter, lintGutter, type Diagnostic } from "@codemirror/lint";
 import { autocompletion, completionKeymap } from "@codemirror/autocomplete";
 import { indentWithTab } from "@codemirror/commands";
 import { keymap } from "@codemirror/view";
-import { bracketMatching, foldGutter } from "@codemirror/language";
+import {
+	bracketMatching,
+	foldGutter,
+	HighlightStyle,
+	syntaxHighlighting,
+} from "@codemirror/language";
+import { tags } from "@lezer/highlight";
 import * as S from "./styles";
+
+/** 구두점·연산자 구분이 잘 되도록 한쪽은 회색·한쪽은 청록 톤 */
+const READABLE_MONO_FONT =
+	'ui-monospace, SFMono-Regular, "SF Mono", Menlo, "Cascadia Mono", "Segoe UI Mono", Consolas, "Liberation Mono", monospace';
+
+const readableDarkHighlight = HighlightStyle.define([
+	{ tag: tags.keyword, color: "#c678dd" },
+	{ tag: tags.atom, color: "#d19a66" },
+	{ tag: tags.bool, color: "#d19a66" },
+	{ tag: tags.literal, color: "#56b6c2" },
+	{ tag: tags.number, color: "#d19a66" },
+	{ tag: tags.comment, color: "#7f848e", fontStyle: "italic" },
+	{ tag: tags.lineComment, color: "#7f848e", fontStyle: "italic" },
+	{ tag: tags.blockComment, color: "#7f848e", fontStyle: "italic" },
+	{ tag: tags.docComment, color: "#7f848e", fontStyle: "italic" },
+	{ tag: tags.string, color: "#98c379" },
+	{ tag: tags.character, color: "#98c379" },
+	{ tag: tags.regexp, color: "#56b6c2" },
+	{ tag: tags.tagName, color: "#e06c75" },
+	{ tag: tags.attributeName, color: "#d19a66" },
+	{ tag: tags.attributeValue, color: "#98c379" },
+	{ tag: tags.annotation, color: "#e5c07b" },
+	{ tag: tags.variableName, color: "#e06c75" },
+	{ tag: tags.propertyName, color: "#e06c75" },
+	{ tag: tags.labelName, color: "#e06c75" },
+	{ tag: tags.function(tags.variableName), color: "#61afef" },
+	{ tag: tags.typeName, color: "#e5c07b" },
+	{ tag: tags.namespace, color: "#e5c07b" },
+	{ tag: tags.className, color: "#e5c07b" },
+	{ tag: tags.macroName, color: "#61afef" },
+	{ tag: tags.operator, color: "#56b6c2" },
+	{ tag: tags.operatorKeyword, color: "#c678dd" },
+	{ tag: tags.bracket, color: "#abb2bf" },
+	{ tag: tags.brace, color: "#abb2bf" },
+	{ tag: tags.paren, color: "#abb2bf" },
+	{ tag: tags.squareBracket, color: "#abb2bf" },
+	{ tag: tags.angleBracket, color: "#abb2bf" },
+	{ tag: tags.punctuation, color: "#d4d4d8" },
+	{ tag: tags.separator, color: "#d4d4d8" },
+	{ tag: tags.meta, color: "#abb2bf" },
+	{ tag: tags.invalid, color: "#f44747" },
+]);
+
+const readableLightHighlight = HighlightStyle.define([
+	{ tag: tags.keyword, color: "#a626a4" },
+	{ tag: tags.atom, color: "#986801" },
+	{ tag: tags.bool, color: "#986801" },
+	{ tag: tags.literal, color: "#0184bc" },
+	{ tag: tags.number, color: "#986801" },
+	{ tag: tags.comment, color: "#a0a1a7", fontStyle: "italic" },
+	{ tag: tags.lineComment, color: "#a0a1a7", fontStyle: "italic" },
+	{ tag: tags.blockComment, color: "#a0a1a7", fontStyle: "italic" },
+	{ tag: tags.docComment, color: "#a0a1a7", fontStyle: "italic" },
+	{ tag: tags.string, color: "#50a14f" },
+	{ tag: tags.character, color: "#50a14f" },
+	{ tag: tags.regexp, color: "#0184bc" },
+	{ tag: tags.variableName, color: "#e45649" },
+	{ tag: tags.propertyName, color: "#e45649" },
+	{ tag: tags.labelName, color: "#e45649" },
+	{ tag: tags.function(tags.variableName), color: "#4078f2" },
+	{ tag: tags.typeName, color: "#c18401" },
+	{ tag: tags.namespace, color: "#c18401" },
+	{ tag: tags.className, color: "#c18401" },
+	{ tag: tags.operator, color: "#0184bc" },
+	{ tag: tags.operatorKeyword, color: "#a626a4" },
+	{ tag: tags.bracket, color: "#383a42" },
+	{ tag: tags.brace, color: "#383a42" },
+	{ tag: tags.paren, color: "#383a42" },
+	{ tag: tags.squareBracket, color: "#383a42" },
+	{ tag: tags.angleBracket, color: "#383a42" },
+	{ tag: tags.punctuation, color: "#24292f" },
+	{ tag: tags.separator, color: "#24292f" },
+	{ tag: tags.meta, color: "#696c77" },
+]);
+
+const editorChromeTheme = EditorView.theme({
+	".cm-editor": {
+		fontSize: "14px",
+		lineHeight: "1.55",
+		fontFamily: READABLE_MONO_FONT,
+		fontFeatureSettings: '"liga" 0',
+	},
+	".cm-content": {
+		fontFamily: READABLE_MONO_FONT,
+	},
+});
 
 interface AssignmentInfo {
 	dueDate?: string;
@@ -265,47 +357,43 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 		}
 	};
 
-	const customDarkTheme = EditorView.theme(
+	const darkChromeTheme = EditorView.theme(
 		{
 			"&": {
-				color: "#ffffff !important",
-				backgroundColor: "#000000 !important",
+				backgroundColor: "#0d1117",
 			},
-			".cm-content": {
-				caretColor: "#ffffff !important",
-				color: "#ffffff !important",
-			},
-			".cm-line": {
-				color: "#ffffff !important",
+			".cm-scroller": {
+				backgroundColor: "#0d1117",
 			},
 			"&.cm-focused .cm-cursor": {
-				borderLeftColor: "#ffffff",
+				borderLeftColor: "#e6edf3",
 			},
 			"&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection":
 				{
-					backgroundColor: "#0066cc",
+					backgroundColor: "#264f78",
 				},
 			".cm-activeLine": {
-				backgroundColor: "#1a1a1a",
+				backgroundColor: "#161b22",
 			},
 			".cm-gutters": {
-				backgroundColor: "#000000",
-				color: "#ffffff",
+				backgroundColor: "#0d1117",
+				color: "#6e7681",
 				border: "none",
+				borderRight: "1px solid #30363d",
 			},
 			".cm-lineNumbers .cm-gutterElement": {
-				color: "#ffffff",
+				color: "#6e7681",
 			},
 			".cm-foldGutter .cm-gutterElement": {
-				color: "#ffffff",
+				color: "#6e7681",
 			},
 			".cm-lintGutter .cm-gutterElement": {
-				color: "#ffffff",
+				color: "#6e7681",
 			},
 			".cm-tooltip": {
-				backgroundColor: "#000000",
-				color: "#ffffff",
-				border: "1px solid #333",
+				backgroundColor: "#161b22",
+				color: "#e6edf3",
+				border: "1px solid #30363d",
 			},
 			".cm-lintPoint": {
 				position: "relative",
@@ -327,42 +415,30 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 				backgroundColor: "rgba(255, 255, 0, 0.2)",
 				border: "1px solid yellow",
 			},
-			".cm-keyword": { color: "#ffffff !important" },
-			".cm-operator": { color: "#ffffff !important" },
-			".cm-variable": { color: "#ffffff !important" },
-			".cm-variable-2": { color: "#ffffff !important" },
-			".cm-variable-3": { color: "#ffffff !important" },
-			".cm-property": { color: "#ffffff !important" },
-			".cm-definition": { color: "#ffffff !important" },
-			".cm-type": { color: "#ffffff !important" },
-			".cm-string": { color: "#ffffff !important" },
-			".cm-string-2": { color: "#ffffff !important" },
-			".cm-number": { color: "#ffffff !important" },
-			".cm-comment": { color: "#ffffff !important" },
-			".cm-attribute": { color: "#ffffff !important" },
-			".cm-meta": { color: "#ffffff !important" },
-			".cm-builtin": { color: "#ffffff !important" },
-			".cm-tag": { color: "#ffffff !important" },
-			".cm-header": { color: "#ffffff !important" },
-			".cm-hr": { color: "#ffffff !important" },
-			".cm-link": { color: "#ffffff !important" },
-			".cm-url": { color: "#ffffff !important" },
-			".cm-formatting": { color: "#ffffff !important" },
-			".cm-formatting-link": { color: "#ffffff !important" },
-			".cm-formatting-list": { color: "#ffffff !important" },
-			".cm-formatting-quote": { color: "#ffffff !important" },
-			".cm-formatting-strong": { color: "#ffffff !important" },
-			".cm-formatting-em": { color: "#ffffff !important" },
-			".cm-formatting-header": { color: "#ffffff !important" },
-			".cm-formatting-header-1": { color: "#ffffff !important" },
-			".cm-formatting-header-2": { color: "#ffffff !important" },
-			".cm-formatting-header-3": { color: "#ffffff !important" },
-			".cm-formatting-header-4": { color: "#ffffff !important" },
-			".cm-formatting-header-5": { color: "#ffffff !important" },
-			".cm-formatting-header-6": { color: "#ffffff !important" },
 		},
 		{ dark: true },
 	);
+
+	const lightChromeTheme = EditorView.theme({
+		"&": {
+			backgroundColor: "#ffffff",
+		},
+		".cm-scroller": {
+			backgroundColor: "#ffffff",
+		},
+		".cm-gutters": {
+			backgroundColor: "#f6f8fa",
+			color: "#656d76",
+			border: "none",
+			borderRight: "1px solid #d0d7de",
+		},
+		".cm-lineNumbers .cm-gutterElement": {
+			color: "#656d76",
+		},
+		".cm-activeLine": {
+			backgroundColor: "#f6f8fa",
+		},
+	});
 
 	return (
 		<S.EditorWrapper>
@@ -481,15 +557,20 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
 					height="100%"
 					extensions={[
 						...getLanguageExtension(language),
-						theme === "dark" ? customDarkTheme : [],
+						editorChromeTheme,
+						theme === "dark" ? darkChromeTheme : lightChromeTheme,
+						syntaxHighlighting(
+							theme === "dark"
+								? readableDarkHighlight
+								: readableLightHighlight,
+						),
 					]}
 					theme={theme === "dark" ? "dark" : "light"}
 					onChange={onCodeChange}
 					editable={!isEditLocked}
 					style={{
-						backgroundColor: theme === "dark" ? "#000000" : "#ffffff",
+						backgroundColor: theme === "dark" ? "#0d1117" : "#ffffff",
 						height: "100%",
-						color: theme === "dark" ? "#ffffff" : "#000000",
 					}}
 				/>
 			</S.EditorScrollArea>

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/CodeEditor/styles.ts
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/CodeEditor/styles.ts
@@ -23,7 +23,7 @@ export const EditorWrapper = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: #000000;
+  background: #0d1117;
   border-bottom: 1px solid #15181c;
   min-height: 0;
 
@@ -45,16 +45,20 @@ export const EditorHeader = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   min-height: 48px;
   box-sizing: border-box;
   flex-shrink: 0;
   flex-grow: 0;
-  max-height: 48px;
 
   .problem-solve-page.light & {
     color: #0969da;
     background: linear-gradient(90deg, rgba(9, 105, 218, 0.1) 0%, rgba(9, 105, 218, 0.05) 100%);
     border-bottom: 1px solid #e1e4e8;
+  }
+
+  @media (max-width: 1200px) {
+    row-gap: 8px;
   }
 `;
 
@@ -195,6 +199,12 @@ export const EditorHeaderRight = styled.div`
   gap: 12px;
   position: relative;
   z-index: 100;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+
+  @media (max-width: 1200px) {
+    gap: 8px;
+  }
 `;
 
 export const DueDateInfo = styled.div`
@@ -233,6 +243,7 @@ export const SubmitButton = styled.button<{ $variant?: "test" | "save" }>`
   cursor: pointer;
   font-weight: 500;
   transition: background-color 0.2s ease;
+  white-space: nowrap;
 
   ${(props) =>
 		props.$variant === "test" &&
@@ -259,6 +270,11 @@ export const SubmitButton = styled.button<{ $variant?: "test" | "save" }>`
     background-color: #6c757d;
     color: #ffffff;
   }
+
+  @media (max-width: 1200px) {
+    padding: 6px 10px;
+    font-size: 11px;
+  }
 `;
 
 export const SaveWarning = styled.span`
@@ -272,6 +288,10 @@ export const SaveReminder = styled.span`
   font-weight: 700;
   color: #ff9f1c;
   white-space: nowrap;
+
+  @media (max-width: 1200px) {
+    font-size: 11px;
+  }
 `;
 
 export const BlinkingSaveButton = styled(SubmitButton)`
@@ -293,7 +313,7 @@ export const BlinkingSaveButton = styled(SubmitButton)`
 export const EditorScrollArea = styled.div`
   flex: 1;
   overflow: auto;
-  background-color: #000000;
+  background-color: #0d1117;
 
   .problem-solve-page.light & {
     background-color: #ffffff;

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/DraggablePanel/index.tsx
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/DraggablePanel/index.tsx
@@ -51,7 +51,7 @@ const DraggablePanel: React.FC<DraggablePanelProps> = ({
 			}
 		},
 		collect: (monitor) => ({
-			isOver: monitor.isOver(),
+			isOver: monitor.isOver({ shallow: true }),
 			canDrop: monitor.canDrop(),
 		}),
 	}));
@@ -75,18 +75,17 @@ const DraggablePanel: React.FC<DraggablePanelProps> = ({
 		>
 			<S.Panel data-panel-id={id} $dragging={isDragging}>
 				{showDragHandle && (
-					<div
+					<S.DragHandle
 						ref={drag as unknown as React.Ref<HTMLDivElement>}
-						style={{ cursor: isDragging ? "grabbing" : "grab" }}
+						$dragging={isDragging}
+						data-dragging={isDragging ? "true" : "false"}
 					>
-						<S.DragHandle $dragging={isDragging}>
-							<S.DragIcon>⋮⋮</S.DragIcon>
-							<S.PanelTitle>{title}</S.PanelTitle>
-							{isOver && canDropHere && (
-								<S.DropIndicator>Drop here to swap panels</S.DropIndicator>
-							)}
-						</S.DragHandle>
-					</div>
+						<S.DragIcon>⋮⋮</S.DragIcon>
+						<S.PanelTitle>{title}</S.PanelTitle>
+						{isOver && canDropHere && (
+							<S.DropIndicator>Drop here to swap panels</S.DropIndicator>
+						)}
+					</S.DragHandle>
 				)}
 				<S.PanelContent>{children}</S.PanelContent>
 			</S.Panel>

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/DraggablePanel/styles.ts
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/DraggablePanel/styles.ts
@@ -38,16 +38,15 @@ export const Panel = styled.div<{ $dragging?: boolean }>`
 
 export const DragHandle = styled.div<{ $dragging?: boolean }>`
   position: absolute;
-  top: 24px;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  top: 10px;
+  left: 13vw;
   display: flex;
   align-items: center;
   gap: 8px;
   background: rgba(0, 0, 0, 0.8);
-  padding: 6px 10px;
+  padding: 8px 12px;
   border-radius: 6px;
-  z-index: 10;
+  z-index: 2000;
   opacity: 0;
   transition: all 0.2s ease;
   cursor: ${(props) => (props.$dragging ? "grabbing" : "grab")};
@@ -57,7 +56,6 @@ export const DragHandle = styled.div<{ $dragging?: boolean }>`
 
   ${Panel}:hover & {
     opacity: 1;
-    transform: translate(-50%, -52%);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   }
 
@@ -67,7 +65,6 @@ export const DragHandle = styled.div<{ $dragging?: boolean }>`
     opacity: 1;
     background: rgba(88, 166, 255, 0.9);
     border-color: rgba(255, 255, 255, 0.5);
-    transform: translate(-50%, -54%);
     box-shadow: 0 6px 16px rgba(88, 166, 255, 0.5);
   `}
 

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/hooks/useCodingQuizSolve.ts
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/hooks/useCodingQuizSolve.ts
@@ -55,8 +55,8 @@ export function useCodingQuizSolve() {
 	const [isLoading, setIsLoading] = useState(true);
 	// Phase 2 폴링 타이머 ref (컴포넌트 언마운트 또는 문제 전환 시 정리)
 	const pollingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const [horizontalSizes, setHorizontalSizes] = useState([40, 60]);
-	const [verticalSizes, setVerticalSizes] = useState([70, 30]);
+	const [horizontalSizes, setHorizontalSizes] = useState([28, 72]);
+	const [verticalSizes, setVerticalSizes] = useState([82, 18]);
 	const [isTimeUp, setIsTimeUp] = useState(false);
 	const [panelLayout, setPanelLayout] = useState<PanelLayout>({
 		left: "description",

--- a/src/pages/Course/Dashboard/CourseDashboardPage/components/CourseDashboardView.tsx
+++ b/src/pages/Course/Dashboard/CourseDashboardPage/components/CourseDashboardView.tsx
@@ -239,6 +239,69 @@ const CourseDashboardView: React.FC<CourseDashboardViewProps> = (d) => {
 								)}
 							</S.ContentBox>
 						</S.Subsection>
+
+						{/* 학습 진행 카드 — 일시 비표시
+						<S.Subsection>
+							<S.SubsectionTitle>학습 진행</S.SubsectionTitle>
+							<S.ContentBox>
+								{(() => {
+									const sp = d.studyProgress;
+									if (sp.loading) {
+										return (
+											<S.NoContent>
+												<span>진행 현황을 불러오는 중입니다.</span>
+											</S.NoContent>
+										);
+									}
+									if (sp.error) {
+										return (
+											<S.NoContent>
+												<span>진행 현황을 불러오지 못했습니다.</span>
+											</S.NoContent>
+										);
+									}
+									const assignPct =
+										sp.assignmentTotalProblems > 0
+											? Math.round(
+													(sp.assignmentSolvedProblems /
+														sp.assignmentTotalProblems) *
+														100,
+												)
+											: 0;
+									const quizPct =
+										sp.quizTotalProblems > 0
+											? Math.round(
+													(sp.quizSolvedProblems / sp.quizTotalProblems) * 100,
+												)
+											: 0;
+									return (
+										<S.StudyProgressRows>
+											<S.StudyProgressLine>
+												<strong>과제</strong> (마감 전{" "}
+												{sp.assignmentUpcomingCount}개): 문제{" "}
+												{sp.assignmentSolvedProblems}/
+												{sp.assignmentTotalProblems} 제출 ·{" "}
+												{sp.assignmentTotalProblems > 0 ? `${assignPct}%` : "—"}
+												<br />
+												<S.StudyProgressMuted>
+													마감일이 지난 과제는 집계에서 제외됩니다.
+												</S.StudyProgressMuted>
+											</S.StudyProgressLine>
+											<S.StudyProgressLine>
+												<strong>코딩 테스트</strong> (전체 {sp.quizCount}개): 정답
+												문제 {sp.quizSolvedProblems}/{sp.quizTotalProblems} ·{" "}
+												{sp.quizTotalProblems > 0 ? `${quizPct}%` : "—"}
+												<br />
+												<S.StudyProgressMuted>
+													퀴즈별 채점 결과가 AC인 문제만 &quot;정답&quot;으로 집계합니다.
+												</S.StudyProgressMuted>
+											</S.StudyProgressLine>
+										</S.StudyProgressRows>
+									);
+								})()}
+							</S.ContentBox>
+						</S.Subsection>
+						*/}
 					</S.LeftColumn>
 
 					<S.RightColumn>

--- a/src/pages/Course/Dashboard/CourseDashboardPage/hooks/useCourseDashboard.ts
+++ b/src/pages/Course/Dashboard/CourseDashboardPage/hooks/useCourseDashboard.ts
@@ -12,6 +12,7 @@ import type {
 	Notification,
 	TransformedNotification,
 	SectionNewItems,
+	StudyProgressSummary,
 } from "../types";
 import { calculateDDay } from "../utils/dateUtils";
 import { extractEnrollmentCode } from "../utils/enrollmentUtils";
@@ -49,6 +50,16 @@ export function useCourseDashboard() {
 		[],
 	);
 	const [sectionQuizzes, setSectionQuizzes] = useState<SectionQuiz[]>([]);
+	const [studyProgress, setStudyProgress] = useState<StudyProgressSummary>({
+		loading: true,
+		error: false,
+		assignmentUpcomingCount: 0,
+		assignmentSolvedProblems: 0,
+		assignmentTotalProblems: 0,
+		quizCount: 0,
+		quizSolvedProblems: 0,
+		quizTotalProblems: 0,
+	});
 
 	const publicSections: CourseCardData[] = [];
 
@@ -367,6 +378,127 @@ export function useCourseDashboard() {
 		fetchSectionQuizzes,
 	]);
 
+	useEffect(() => {
+		const user = auth.user;
+		if (sectionId == null || user?.id == null) {
+			setStudyProgress((prev) => ({ ...prev, loading: false }));
+			return;
+		}
+		const userId = user.id;
+		let cancelled = false;
+		setStudyProgress((prev) => ({ ...prev, loading: true, error: false }));
+
+		const run = async () => {
+			try {
+				const now = Date.now();
+				const [assignRes, quizRes] = await Promise.all([
+					APIService.getAssignmentsBySection(sectionId),
+					APIService.getQuizzesBySection(sectionId),
+				]);
+				const assignmentsRaw =
+					(assignRes as { data?: unknown })?.data ?? assignRes ?? [];
+				const quizzesRaw = (quizRes as { data?: unknown })?.data ?? quizRes ?? [];
+				const assignmentsList = Array.isArray(assignmentsRaw)
+					? assignmentsRaw
+					: [];
+				const quizzesList = Array.isArray(quizzesRaw) ? quizzesRaw : [];
+
+				const upcoming = assignmentsList.filter((a: { endDate?: string }) => {
+					if (!a?.endDate) return false;
+					const t = new Date(a.endDate).getTime();
+					return !Number.isNaN(t) && t >= now;
+				});
+
+				const assignmentChunks = await Promise.all(
+					upcoming.map(async (a: { id: number }) => {
+						try {
+							const [problemsRes, statusRes] = await Promise.all([
+								APIService.getAssignmentProblems(sectionId, a.id),
+								APIService.getStudentAssignmentProblemsStatus(
+									userId,
+									sectionId,
+									a.id,
+								),
+							]);
+							const problemsList =
+								(problemsRes as { data?: unknown })?.data ?? problemsRes ?? [];
+							const problemsStatus =
+								(statusRes as { data?: unknown })?.data ?? statusRes ?? [];
+							const total = Array.isArray(problemsList) ? problemsList.length : 0;
+							const solved = Array.isArray(problemsStatus)
+								? problemsStatus.filter(
+										(s: { status?: string }) =>
+											s.status === "ACCEPTED" || s.status === "SUBMITTED",
+									).length
+								: 0;
+							return { total, solved };
+						} catch {
+							return { total: 0, solved: 0 };
+						}
+					}),
+				);
+				const assignmentTotalProblems = assignmentChunks.reduce(
+					(s, x) => s + x.total,
+					0,
+				);
+				const assignmentSolvedProblems = assignmentChunks.reduce(
+					(s, x) => s + x.solved,
+					0,
+				);
+
+				const quizChunks = await Promise.all(
+					quizzesList.map(async (q: { id: number }) => {
+						try {
+							const statusRes = await APIService.getQuizProblemStatuses(
+								sectionId,
+								q.id,
+							);
+							const statuses =
+								(statusRes as { data?: unknown })?.data ?? statusRes ?? [];
+							if (!Array.isArray(statuses)) return { total: 0, solved: 0 };
+							const total = statuses.length;
+							const solved = statuses.filter(
+								(s: { submitted?: boolean; result?: string | null }) =>
+									Boolean(s.submitted) && s.result === "AC",
+							).length;
+							return { total, solved };
+						} catch {
+							return { total: 0, solved: 0 };
+						}
+					}),
+				);
+				const quizTotalProblems = quizChunks.reduce((s, x) => s + x.total, 0);
+				const quizSolvedProblems = quizChunks.reduce((s, x) => s + x.solved, 0);
+
+				if (!cancelled) {
+					setStudyProgress({
+						loading: false,
+						error: false,
+						assignmentUpcomingCount: upcoming.length,
+						assignmentSolvedProblems,
+						assignmentTotalProblems,
+						quizCount: quizzesList.length,
+						quizSolvedProblems,
+						quizTotalProblems,
+					});
+				}
+			} catch {
+				if (!cancelled) {
+					setStudyProgress((prev) => ({
+						...prev,
+						loading: false,
+						error: true,
+					}));
+				}
+			}
+		};
+
+		void run();
+		return () => {
+			cancelled = true;
+		};
+	}, [sectionId, auth.user]);
+
 	const handleMenuClick = useCallback((_menuId: string) => {}, []);
 
 	const handleQuizSummaryClick = useCallback(
@@ -518,6 +650,7 @@ export function useCourseDashboard() {
 		handleEnrollByCode,
 		calculateDDay,
 		navigate,
+		studyProgress,
 	};
 }
 

--- a/src/pages/Course/Dashboard/CourseDashboardPage/styles.ts
+++ b/src/pages/Course/Dashboard/CourseDashboardPage/styles.ts
@@ -327,6 +327,24 @@ export const QuizSummaryMeta = styled.span`
   flex-shrink: 0;
 `;
 
+export const StudyProgressRows = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const StudyProgressLine = styled.p`
+  margin: 0;
+  font-size: 0.88rem;
+  color: #374151;
+  line-height: 1.55;
+`;
+
+export const StudyProgressMuted = styled.span`
+  color: #6b7280;
+  font-size: 0.82rem;
+`;
+
 export const CoursesSection = styled.div`
   flex: 0 0 auto;
   display: flex;

--- a/src/pages/Course/Dashboard/CourseDashboardPage/types.ts
+++ b/src/pages/Course/Dashboard/CourseDashboardPage/types.ts
@@ -69,6 +69,22 @@ export interface Assignment {
 	totalProblems?: number;
 }
 
+/** 대시보드 좌측 '학습 진행' 카드용 집계 */
+export interface StudyProgressSummary {
+	loading: boolean;
+	error: boolean;
+	/** 마감일이 아직 지나지 않은 과제 개수 */
+	assignmentUpcomingCount: number;
+	/** 마감 전 과제들에서 제출 처리된 문제 수 (과제 목록과 동일 기준) */
+	assignmentSolvedProblems: number;
+	assignmentTotalProblems: number;
+	/** 이 수업의 코딩 테스트 개수 */
+	quizCount: number;
+	/** 전체 퀴즈에서 채점 결과가 AC인 문제 수 합 */
+	quizSolvedProblems: number;
+	quizTotalProblems: number;
+}
+
 export interface Notification {
 	id: number;
 	sectionId: number;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #202 

## 📝작업 내용

# Issue

# 코딩 테스트 풀이 화면: 에디터 가독성 · 과제 영역(패널) 간 이동

## 1. 코드 에디터(CodeMirror) 가독성

### 문제

- 구두점·연산자 등 구분이 어렵고 가독성이 낮음.
- 다크 테마에서 본문 글자색을 강제로 덮어 **구문 하이라이트가 무력화**되는 경우가 있었음.

### 적용 파일

- `CodingQuizSolvePage/CodeEditor/index.tsx`
- `CodingQuizSolvePage/CodeEditor/styles.ts`

### 내용 요약

- `HighlightStyle` + `syntaxHighlighting`, `@lezer/highlight`의 `tags`로 토큰별 색 분리 (연산자 vs 구두점 등).
- 모노스페이스 폰트 스택, 줄간격, `fontFeatureSettings: '"liga" 0'`.
- 다크/라이트 각각 하이라이트·크롬 테마(`EditorView.theme`).
- 인라인 `color` 강제 제거로 하이라이트가 적용되도록 정리.
- 다크 모드에서 에디터 래퍼/스크롤 영역 배경을 **`#0d1117`** 로 본문 톤과 맞춤.

---

## 2. 과제 영역(문제 설명 ↔ 에디터 ↔ 실행 결과) 배치 · 이동

### UX 개요

- 화면은 **좌측 1칸 + 우측 상하 2칸**(`react-split`) 구조.
- 각 칸은 **문제 설명(`description`) / 코드 에디터(`editor`) / 실행 결과(`result`)** 중 하나를 담으며, 기본값은 좌=설명, 우상=에디터, 우하=결과.
- 패널 위 **`⋮⋮` 드래그 핸들**로 다른 패널 위에 드롭하면 **두 칸의 내용이 서로 맞바뀜**(swap).

### 적용 파일

- `CodingQuizSolvePage/components/CodingQuizSolveView.tsx` — `DndProvider`, `Split` 분할, `DraggablePanel`로 각 패널 감쌈.
- `CodingQuizSolvePage/DraggablePanel/index.tsx` — `react-dnd`의 `useDrag` / `useDrop`, 드롭 시 `onMove(draggedId, targetId)` 호출.
- `CodingQuizSolvePage/DraggablePanel/styles.ts` — 패널·드래그 핸들 스타일(호버/드래그 중 강조, 라이트 테마 `.problem-solve-page.light` 대응).
- `CodingQuizSolvePage/hooks/useCodingQuizSolve.ts` — `panelLayout` 상태(`left`, `topRight`, `bottomRight`)와 `handlePanelMove`로 두 슬롯의 패널 id 교환.

### 확인 포인트

- [ ] 세 패널을 서로 바꿔도 스크롤·에디터 동작에 문제 없는지.
- [ ] 다크/라이트에서 드래그 핸들·호버 테두리가 잘 보이는지.
- [ ] 가로·세로 **스플리터(gutter) 드래그**로 영역 크기 조절이 기존과 동일한지 (`horizontalSizes` / `verticalSizes` 등).

---
# FE: 과제 목록 정렬 · 과제↔문제 이동 모달

현재 브랜치에서 **과제(Assignments)** 쪽 UX와 **풀이 화면**에서 과제·문제 전환을 다룬 변경 요약입니다.

---

## 1. 과제 목록 페이지 — 정렬(필터)

**경로:** `Course/Assignments/CourseAssignmentsPage/`

- 상단 **`assignmentSort`** (`recentFirst` | `oldestFirst` | `unsolvedFirst`) 드롭다운으로 목록 순서 변경.
  - **최근 추가순** / **오래된 과제순** / **미해결 문제 많은순**
- `useCourseAssignmentsPage.ts`의 `sortedAssignments`(`useMemo`)에서 선택값에 따라 정렬.
- 헤더 요약: 과제 수·문제 수·기본 정렬 안내 등 (`CourseAssignmentsPageView.tsx`).

**관련 파일**

- `hooks/useCourseAssignmentsPage.ts`
- `components/CourseAssignmentsPageView.tsx`
- `styles.ts` (배치용 컴포넌트명은 프로젝트 기준)

---

## 2. 과제 풀이 페이지 — 과제 ↔ 문제 이동 모달

**경로:** `AssignmentPage/ProblemSolvePage/`

### 공통 UI 패턴

- 코딩 퀴즈 풀이의 **`ProblemSelectModal` 스타일**을 재사용 (`CodingQuizSolvePage/ProblemSelectModal/styles`를 `AssignmentSelectModal`에서 import).

### (A) 같은 과제 안에서 다른 문제로 이동 — `ProblemSelectModal`

- 코딩 퀴즈와 동일 컴포넌트 사용 (`CodingQuizSolvePage/ProblemSelectModal`).
- 문제별 상태 라벨(제출·정답·저장됨 등)은 `problemStatusById` 등으로 표시.

### (B) 다른 과제로 이동 — `AssignmentSelectModal` (“과제 이동”)

- 섹션 내 과제 목록에서 선택 → **선택한 과제의 첫 번째 문제**로 라우팅.
- 안내: 미저장 코드 시 확인 (`저장되지 않은 코드가 있으면 확인합니다`).
- 로직: `handleSelectOtherAssignment`에서 `getAssignmentProblems`로 문제 목록 조회 → 정렬 후 첫 `problemId`로 `requestNavigateToProblem`.

### 미저장 변경 시 확인 모달

- 문제/과제 이동 전 코드가 저장본과 다르면 **`showUnsavedModal`**.
  - 저장하고 이동 / 저장 없이 이동 / 취소  
- 내비게이션 대상은 `pendingNavigationRef` / `pendingProblemId` 패턴과 동일 계열.

**관련 파일**

- `hooks/useProblemSolve.ts` — 모달 상태, `handleProblemChange`, `handleSelectOtherAssignment`, 미저장 처리·네비게이션.
- `components/ProblemSolveView.tsx` — `ProblemSelectModal`, `AssignmentSelectModal`, 버튼으로 모달 오픈.
- `components/AssignmentSelectModal/index.tsx`

---

## 3. 확인 체크리스트

- [ ] 과제 목록: 세 정렬 옵션별 순서가 기대와 일치하는지.
- [ ] 풀이 화면: **다른 문제로 이동** 후 코드·세션 로드 정상 여부.
- [ ] 풀이 화면: **다른 과제로 이동** 시 첫 문제 진입·빈 과제 처리 알림.
- [ ] 미저장 상태에서 문제/과제 전환 시 세 가지 선택 동작.

---

