### PR TITLE
fix/issue-214/과제정답시문제목록표시및강의로돌아가기경로설정

### DIFF
--- a/src/layouts/TutorLayout/index.tsx
+++ b/src/layouts/TutorLayout/index.tsx
@@ -337,7 +337,9 @@ const TutorLayout: React.FC<TutorLayoutProps> = ({
 	const mainMenuItems = useMemo<MenuItem[]>(
 		() => [
 			{
-				path: "/dashboard",
+				path: currentSection
+					? `/sections/${currentSection.sectionId}/dashboard`
+					: "/dashboard",
 				label: "강의로 돌아가기",
 				icon: FaArrowLeft,
 				subItems: [],
@@ -370,7 +372,7 @@ const TutorLayout: React.FC<TutorLayoutProps> = ({
 				],
 			},
 		],
-		[],
+		[currentSection],
 	);
 
 	const handleMenuClick = useCallback(

--- a/src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx
@@ -11,6 +11,7 @@ import ProblemSelectModal from "../../../Course/CodingQuiz/CodingQuizSolvePage/P
 import AssignmentSelectModal from "./AssignmentSelectModal";
 import type { PanelKey } from "../hooks/useProblemSolve";
 import type { Problem } from "../types";
+import type { ProblemWorkStatus } from "../../../Course/CodingQuiz/CodingQuizSolvePage/types";
 import * as S from "../styles";
 
 interface ProblemSolveViewProps {
@@ -39,6 +40,7 @@ interface ProblemSolveViewProps {
 	verticalSizes: number[];
 	panelLayout: { left: PanelKey; topRight: PanelKey; bottomRight: PanelKey };
 	problems: Array<{ id: number; title: string; order: number }>;
+	problemStatusById: Record<number, ProblemWorkStatus>;
 	isProblemModalOpen: boolean;
 	isProblemChanging: boolean;
 	setIsProblemModalOpen: (open: boolean) => void;
@@ -99,6 +101,7 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 		verticalSizes,
 		panelLayout,
 		problems,
+		problemStatusById,
 		isProblemModalOpen,
 		isProblemChanging,
 		setIsProblemModalOpen,
@@ -323,6 +326,7 @@ const ProblemSolveView: React.FC<ProblemSolveViewProps> = (props) => {
 					isOpen={isProblemModalOpen}
 					problems={problems}
 					currentProblemId={currentProblem.id ?? null}
+					problemStatusById={problemStatusById}
 					isChanging={isProblemChanging}
 					onClose={() => setIsProblemModalOpen(false)}
 					onSelectProblem={(pid) => {

--- a/src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts
+++ b/src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts
@@ -12,6 +12,7 @@ import {
 	RESULT_MAPPING_OUTPUT,
 } from "../utils/resultMappings";
 import type { Problem, SubmissionResultState } from "../types";
+import type { ProblemWorkStatus } from "../../../Course/CodingQuiz/CodingQuizSolvePage/types";
 
 export type TestcaseResult = { index: number; result: string };
 
@@ -92,6 +93,9 @@ export function useProblemSolve() {
 	const [sectionAssignments, setSectionAssignments] = useState<
 		SectionAssignmentSummary[]
 	>([]);
+	const [problemStatusById, setProblemStatusById] = useState<
+		Record<number, ProblemWorkStatus>
+	>({});
 	const auth = useRecoilValue(authState);
 
 	// 마지막으로 서버에 저장된 코드 (hasUnsavedChanges 판단 기준)
@@ -106,6 +110,76 @@ export function useProblemSolve() {
 	const testcaseOutputAccumRef = useRef<NonNullable<SubmissionResultState["outputList"]>>([]);
 	const [showUnsavedModal, setShowUnsavedModal] = useState(false);
 	const pendingNavigationRef = useRef<PendingNavigation | null>(null);
+
+	const mergeStatusesFromApi = useCallback(
+		(
+			response: unknown,
+			prev: Record<number, ProblemWorkStatus>,
+		): Record<number, ProblemWorkStatus> => {
+			const root =
+				typeof response === "object" &&
+				response !== null &&
+				"data" in (response as Record<string, unknown>)
+					? (response as { data: unknown }).data
+					: response;
+			if (!root || typeof root !== "object") return prev;
+			const list = (root as { problemStatuses?: unknown }).problemStatuses;
+			if (!Array.isArray(list)) return prev;
+			const next: Record<number, ProblemWorkStatus> = {};
+			for (const row of list) {
+				const rec = row as Record<string, unknown>;
+				const pid = Number(rec.problemId);
+				if (!Number.isFinite(pid)) continue;
+				const hasSubmitted = Boolean(rec.hasSubmitted);
+				const hasCorrect = Boolean(rec.hasCorrectSubmission);
+				const was = prev[pid];
+				next[pid] = {
+					problemId: pid,
+					submitted: hasSubmitted,
+					result: hasSubmitted ? (hasCorrect ? "AC" : "WA") : null,
+					saved: hasSubmitted ? false : Boolean(was?.saved),
+				};
+			}
+			return next;
+		},
+		[],
+	);
+
+	const refreshProblemStatuses = useCallback(async () => {
+		if (!sectionId || !assignmentId || auth.loading) return;
+		try {
+			const res = await apiService.getUserSubmissionStatus(
+				sectionId,
+				assignmentId,
+			);
+			setProblemStatusById((prev) => mergeStatusesFromApi(res, prev));
+		} catch (e) {
+			console.warn("과제 문제 제출 상태 조회 실패:", e);
+		}
+	}, [sectionId, assignmentId, auth.loading, mergeStatusesFromApi]);
+
+	useEffect(() => {
+		if (
+			!sectionId ||
+			!assignmentId ||
+			problems.length === 0 ||
+			auth.loading
+		)
+			return;
+		void refreshProblemStatuses();
+	}, [sectionId, assignmentId, problems, auth.loading, refreshProblemStatuses]);
+
+	useEffect(() => {
+		if (!isProblemModalOpen || !sectionId || !assignmentId || auth.loading)
+			return;
+		void refreshProblemStatuses();
+	}, [
+		isProblemModalOpen,
+		sectionId,
+		assignmentId,
+		auth.loading,
+		refreshProblemStatuses,
+	]);
 
 	useEffect(() => {
 		const loadAllInfo = async () => {
@@ -291,6 +365,23 @@ export function useProblemSolve() {
 			localStorage.setItem(`lastServerSave_${problemId}_${sectionId}_${language}`, Date.now().toString());
 			lastSavedCodeRef.current = code;
 			setSessionSaveStatus("saved");
+
+			const pid = Number(problemId);
+			if (Number.isFinite(pid)) {
+				setProblemStatusById((prev) => {
+					const cur = prev[pid];
+					if (cur?.submitted) return prev;
+					return {
+						...prev,
+						[pid]: {
+							problemId: pid,
+							submitted: false,
+							result: null,
+							saved: true,
+						},
+					};
+				});
+			}
 
 			if (showModal) {
 				setShowSaveModal(true);
@@ -554,6 +645,7 @@ export function useProblemSolve() {
 				type: "judge",
 			});
 			await clearSessionAfterSubmission();
+			await refreshProblemStatuses();
 
 		} catch (error: unknown) {
 			if (submissionPollingCancelledRef.current) return;
@@ -586,6 +678,7 @@ export function useProblemSolve() {
 		sectionId,
 		problemId,
 		clearSessionAfterSubmission,
+		refreshProblemStatuses,
 		isAssignmentActive,
 		navigate,
 		userRole,
@@ -968,5 +1061,6 @@ export function useProblemSolve() {
 		handleUnsavedModalSave,
 		handleUnsavedModalSkip,
 		handleUnsavedModalCancel,
+		problemStatusById,
 	};
 }

--- a/src/pages/AssignmentPage/ProblemSolvePage/index.tsx
+++ b/src/pages/AssignmentPage/ProblemSolvePage/index.tsx
@@ -42,6 +42,7 @@ const ProblemSolvePage: React.FC = () => {
 			verticalSizes={hook.verticalSizes}
 			panelLayout={hook.panelLayout}
 			problems={hook.problems}
+			problemStatusById={hook.problemStatusById}
 			isProblemModalOpen={hook.isProblemModalOpen}
 			isProblemChanging={hook.isProblemChanging}
 			setIsProblemModalOpen={hook.setIsProblemModalOpen}

--- a/src/pages/Course/CodingQuiz/CodingQuizSolvePage/hooks/useCodingQuizSolve.ts
+++ b/src/pages/Course/CodingQuiz/CodingQuizSolvePage/hooks/useCodingQuizSolve.ts
@@ -61,8 +61,12 @@ export function useCodingQuizSolve() {
 	const sseAbortControllerRef = useRef<AbortController | null>(null);
 	// SSE로 수신한 테스트케이스 output 누적 (re-render 없이 최종 outputList 구성)
 	const testcaseOutputAccumRef = useRef<any[]>([]);
-	const [testcaseResults, setTestcaseResults] = useState<{ index: number; result: string }[] | null>(null);
-	const [totalTestcaseCount, setTotalTestcaseCount] = useState<number | null>(null);
+	const [testcaseResults, setTestcaseResults] = useState<
+		{ index: number; result: string }[] | null
+	>(null);
+	const [totalTestcaseCount, setTotalTestcaseCount] = useState<number | null>(
+		null,
+	);
 	const [horizontalSizes, setHorizontalSizes] = useState([28, 72]);
 	const [verticalSizes, setVerticalSizes] = useState([82, 18]);
 	const [isTimeUp, setIsTimeUp] = useState(false);
@@ -86,8 +90,7 @@ export function useCodingQuizSolve() {
 	const [nowMs, setNowMs] = useState(Date.now());
 
 	// 시험 중복 접속 방지용 (모든 역할 공통)
-	const [examClientSessionId] = useState<string>(() =>
-	{
+	const [examClientSessionId] = useState<string>(() => {
 		const storageKey = "coding-quiz-client-session-id";
 		if (typeof window !== "undefined") {
 			const existing = window.sessionStorage.getItem(storageKey);
@@ -101,8 +104,7 @@ export function useCodingQuizSolve() {
 			window.sessionStorage.setItem(storageKey, newSessionId);
 		}
 		return newSessionId;
-	},
-	);
+	});
 	const [examSessionConflict, setExamSessionConflict] = useState(false);
 	const [examSessionTakenOver, setExamSessionTakenOver] = useState(false);
 	const problemChangeRequestIdRef = useRef(0);
@@ -146,10 +148,12 @@ export function useCodingQuizSolve() {
 		}
 	}, [auth.isAuthenticated, auth.user, sectionId]);
 
-	const isManager = userRole === "ADMIN" || userRole === "TUTOR" || userRole === "SUPER_ADMIN";
+	const isManager =
+		userRole === "ADMIN" || userRole === "TUTOR" || userRole === "SUPER_ADMIN";
 	const isQuizEndedByTime =
 		!!quizInfo.endTime && nowMs >= quizInfo.endTime.getTime();
-	const isQuizEnded = isTimeUp || quizInfo.status === "ENDED" || isQuizEndedByTime;
+	const isQuizEnded =
+		isTimeUp || quizInfo.status === "ENDED" || isQuizEndedByTime;
 
 	// 학생 제출/테스트 차단: 시간 종료 또는 PAUSED(일시정지) 상태
 	const isSubmitBlocked =
@@ -271,7 +275,10 @@ export function useCodingQuizSolve() {
 		const loadProblemStatuses = async () => {
 			if (!sectionId || !quizId || problems.length === 0) return;
 			try {
-				const response = await apiService.getQuizProblemStatuses(sectionId, quizId);
+				const response = await apiService.getQuizProblemStatuses(
+					sectionId,
+					quizId,
+				);
 				const list = (response?.data ?? response ?? []) as ProblemWorkStatus[];
 				const nextMap: Record<number, ProblemWorkStatus> = {};
 				for (const item of list) {
@@ -313,8 +320,7 @@ export function useCodingQuizSolve() {
 				);
 				const status =
 					(res as { data?: { status?: string }; status?: string })?.data
-						?.status ??
-					(res as { status?: string })?.status;
+						?.status ?? (res as { status?: string })?.status;
 				if (status === "CONFLICT") {
 					setExamSessionConflict(true);
 				}
@@ -346,8 +352,7 @@ export function useCodingQuizSolve() {
 				);
 				const valid =
 					(res as { data?: { valid?: boolean }; valid?: boolean })?.data
-						?.valid ??
-					(res as { valid?: boolean })?.valid;
+						?.valid ?? (res as { valid?: boolean })?.valid;
 				if (valid === false) {
 					setExamSessionTakenOver(true);
 				}
@@ -361,31 +366,61 @@ export function useCodingQuizSolve() {
 
 	useEffect(() => {
 		const loadCode = async () => {
-			if (!selectedProblemId || !sectionId || !language || !sessionId || auth.loading) return;
+			if (
+				!selectedProblemId ||
+				!sectionId ||
+				!language ||
+				!sessionId ||
+				auth.loading
+			)
+				return;
 			try {
 				// IndexedDB와 서버를 동시에 조회
 				const [sessionResult, serverResult] = await Promise.allSettled([
-					indexedDBManager.getSessionCode(selectedProblemId, sectionId, language),
+					indexedDBManager.getSessionCode(
+						selectedProblemId,
+						sectionId,
+						language,
+					),
 					apiService.loadProgress(selectedProblemId, sectionId, language),
 				]);
 
-				const sessionRecord = sessionResult.status === "fulfilled" ? sessionResult.value : null;
-				const serverData = serverResult.status === "fulfilled" ? serverResult.value : null;
+				const sessionRecord =
+					sessionResult.status === "fulfilled" ? sessionResult.value : null;
+				const serverData =
+					serverResult.status === "fulfilled" ? serverResult.value : null;
 
 				const sessionCode = sessionRecord?.code ?? null;
 				const sessionTimestamp = sessionRecord?.timestamp ?? 0;
 
 				const serverSaveKey = `lastServerSave_${selectedProblemId}_${sectionId}_${language}`;
-				const lastServerSaveTime = parseInt(localStorage.getItem(serverSaveKey) ?? "0", 10);
+				const lastServerSaveTime = Number.parseInt(
+					localStorage.getItem(serverSaveKey) ?? "0",
+					10,
+				);
 
-				const raw = serverData as { codeString?: string; code?: string } | string | undefined;
+				const raw = serverData as
+					| { codeString?: string; code?: string }
+					| string
+					| undefined;
 				const serverCode =
 					typeof raw === "object" && raw !== null
 						? (raw?.codeString ?? raw?.code ?? undefined)
-						: typeof raw === "string" ? raw : undefined;
+						: typeof raw === "string"
+							? raw
+							: undefined;
 
-				const isValidSession = Boolean(sessionCode && sessionCode.trim() !== "" && sessionCode !== getDefaultCode(language));
-				const isValidServer = Boolean(serverCode && typeof serverCode === "string" && serverCode.trim() !== "" && serverCode !== getDefaultCode(language));
+				const isValidSession = Boolean(
+					sessionCode &&
+						sessionCode.trim() !== "" &&
+						sessionCode !== getDefaultCode(language),
+				);
+				const isValidServer = Boolean(
+					serverCode &&
+						typeof serverCode === "string" &&
+						serverCode.trim() !== "" &&
+						serverCode !== getDefaultCode(language),
+				);
 
 				if (isValidSession && isValidServer) {
 					if (sessionTimestamp > lastServerSaveTime) {
@@ -419,41 +454,49 @@ export function useCodingQuizSolve() {
 		loadCode();
 	}, [selectedProblemId, sectionId, language, sessionId, auth.loading]);
 
-	const saveToBackend = useCallback(async (showModal = false) => {
-		if (!code || !selectedProblemId || !sectionId) return;
-		try {
-			setSessionSaveStatus("saving");
-			// 서버와 IndexedDB에 동시 저장
-			await Promise.all([
-				apiService.saveProgress(selectedProblemId, sectionId, language, code),
-				indexedDBManager.saveSessionCode(selectedProblemId, sectionId, language, code).catch(() => {}),
-			]);
-			// 서버 저장 시각을 localStorage에 기록 (timestamp 비교용)
-			localStorage.setItem(`lastServerSave_${selectedProblemId}_${sectionId}_${language}`, Date.now().toString());
-			lastSavedCodeRef.current = code;
-			setSessionSaveStatus("saved");
-			setProblemStatusById((prev) => ({
-				...prev,
-				[selectedProblemId]: {
-					problemId: selectedProblemId,
-					submitted: prev[selectedProblemId]?.submitted ?? false,
-					result: prev[selectedProblemId]?.result ?? null,
-					saved: true,
-				},
-			}));
+	const saveToBackend = useCallback(
+		async (showModal = false) => {
+			if (!code || !selectedProblemId || !sectionId) return;
+			try {
+				setSessionSaveStatus("saving");
+				// 서버와 IndexedDB에 동시 저장
+				await Promise.all([
+					apiService.saveProgress(selectedProblemId, sectionId, language, code),
+					indexedDBManager
+						.saveSessionCode(selectedProblemId, sectionId, language, code)
+						.catch(() => {}),
+				]);
+				// 서버 저장 시각을 localStorage에 기록 (timestamp 비교용)
+				localStorage.setItem(
+					`lastServerSave_${selectedProblemId}_${sectionId}_${language}`,
+					Date.now().toString(),
+				);
+				lastSavedCodeRef.current = code;
+				setSessionSaveStatus("saved");
+				setProblemStatusById((prev) => ({
+					...prev,
+					[selectedProblemId]: {
+						problemId: selectedProblemId,
+						submitted: prev[selectedProblemId]?.submitted ?? false,
+						result: prev[selectedProblemId]?.result ?? null,
+						saved: true,
+					},
+				}));
 
-			if (showModal) {
-				setShowSaveModal(true);
-				setTimeout(() => setShowSaveModal(false), 2000);
-			} else {
+				if (showModal) {
+					setShowSaveModal(true);
+					setTimeout(() => setShowSaveModal(false), 2000);
+				} else {
+					setTimeout(() => setSessionSaveStatus("idle"), 2000);
+				}
+			} catch (error) {
+				console.error("저장 실패:", error);
+				setSessionSaveStatus("error");
 				setTimeout(() => setSessionSaveStatus("idle"), 2000);
 			}
-		} catch (error) {
-			console.error("저장 실패:", error);
-			setSessionSaveStatus("error");
-			setTimeout(() => setSessionSaveStatus("idle"), 2000);
-		}
-	}, [code, language, selectedProblemId, sectionId]);
+		},
+		[code, language, selectedProblemId, sectionId],
+	);
 
 	// Ctrl+S 단축키 핸들러
 	useEffect(() => {
@@ -469,9 +512,12 @@ export function useCodingQuizSolve() {
 
 	useEffect(() => {
 		if (isTimeUp) return;
-		const autoSaveInterval = setInterval(() => {
-			saveToBackend(false);
-		}, 5 * 60 * 1000);
+		const autoSaveInterval = setInterval(
+			() => {
+				saveToBackend(false);
+			},
+			5 * 60 * 1000,
+		);
 		return () => clearInterval(autoSaveInterval);
 	}, [isTimeUp, saveToBackend]);
 
@@ -493,7 +539,8 @@ export function useCodingQuizSolve() {
 	// 페이지 이탈/새로고침 시 미저장 변경사항 경고
 	useEffect(() => {
 		const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-			const hasUnsaved = code !== lastSavedCodeRef.current && code !== getDefaultCode(language);
+			const hasUnsaved =
+				code !== lastSavedCodeRef.current && code !== getDefaultCode(language);
 			if (hasUnsaved) {
 				e.preventDefault();
 				e.returnValue = "";
@@ -523,7 +570,11 @@ export function useCodingQuizSolve() {
 	const handleExamSessionTakeover = useCallback(async () => {
 		if (!quizId || !sectionId) return;
 		try {
-			await apiService.takeoverQuizSession(sectionId, quizId, examClientSessionId);
+			await apiService.takeoverQuizSession(
+				sectionId,
+				quizId,
+				examClientSessionId,
+			);
 			setExamSessionConflict(false);
 		} catch (err) {
 			console.error("세션 인계 실패:", err);
@@ -536,7 +587,9 @@ export function useCodingQuizSolve() {
 		timeUpHandled.current = true;
 
 		setIsTimeUp(true);
-		alert("퀴즈 시간이 종료되었습니다. 현재 페이지는 조회 가능하며 제출/수정은 잠금됩니다.");
+		alert(
+			"퀴즈 시간이 종료되었습니다. 현재 페이지는 조회 가능하며 제출/수정은 잠금됩니다.",
+		);
 	}, []);
 
 	// 컴포넌트 언마운트 시 폴링 타이머 및 SSE 연결 정리
@@ -555,14 +608,14 @@ export function useCodingQuizSolve() {
 			if (!sectionId) return;
 			const requestId = ++problemChangeRequestIdRef.current;
 			try {
-			setIsProblemChanging(true);
-			// 문제 전환 시 진행 중인 폴링 타이머 및 SSE 연결 정리
-			if (pollingTimerRef.current) {
-				clearTimeout(pollingTimerRef.current);
-				pollingTimerRef.current = null;
-			}
-			sseAbortControllerRef.current?.abort();
-			sseAbortControllerRef.current = null;
+				setIsProblemChanging(true);
+				// 문제 전환 시 진행 중인 폴링 타이머 및 SSE 연결 정리
+				if (pollingTimerRef.current) {
+					clearTimeout(pollingTimerRef.current);
+					pollingTimerRef.current = null;
+				}
+				sseAbortControllerRef.current?.abort();
+				sseAbortControllerRef.current = null;
 				// 새 문제로 전환 전 상태 초기화
 				lastSavedCodeRef.current = "";
 				setCode(getDefaultCode(language));
@@ -587,10 +640,12 @@ export function useCodingQuizSolve() {
 
 	const handleProblemChange = useCallback(
 		async (problemId: number) => {
-			if (problemId === selectedProblemId || !sectionId || isProblemChanging) return;
+			if (problemId === selectedProblemId || !sectionId || isProblemChanging)
+				return;
 
 			// 미저장 변경사항이 있고 편집 잠금 상태가 아닐 때 → 저장 안내 모달
-			const hasUnsaved = code !== lastSavedCodeRef.current && code !== getDefaultCode(language);
+			const hasUnsaved =
+				code !== lastSavedCodeRef.current && code !== getDefaultCode(language);
 			if (hasUnsaved && !isSubmitBlocked) {
 				pendingProblemIdRef.current = problemId;
 				setShowUnsavedModal(true);
@@ -599,7 +654,15 @@ export function useCodingQuizSolve() {
 
 			await doSwitchProblem(problemId);
 		},
-		[selectedProblemId, sectionId, isProblemChanging, code, language, isSubmitBlocked, doSwitchProblem],
+		[
+			selectedProblemId,
+			sectionId,
+			isProblemChanging,
+			code,
+			language,
+			isSubmitBlocked,
+			doSwitchProblem,
+		],
 	);
 
 	// 저장 안내 모달 핸들러
@@ -701,7 +764,11 @@ export function useCodingQuizSolve() {
 				// 채점 중 상태 표시
 				setSubmissionResult({
 					status: "judging",
-					resultInfo: { status: "judging", message: "채점 중...", color: "#6c757d" },
+					resultInfo: {
+						status: "judging",
+						message: "채점 중...",
+						color: "#6c757d",
+					},
 					submissionDbId,
 					submittedAt,
 					language: submissionLanguage,
@@ -714,7 +781,11 @@ export function useCodingQuizSolve() {
 				setSubmissionResult({
 					status: "error",
 					message,
-					resultInfo: { status: "error", message: "제출 실패", color: "#dc3545" },
+					resultInfo: {
+						status: "error",
+						message: "제출 실패",
+						color: "#dc3545",
+					},
 					type,
 				});
 				setIsSubmitting(false);
@@ -730,8 +801,13 @@ export function useCodingQuizSolve() {
 				if (Date.now() >= pollingDeadline) {
 					setSubmissionResult({
 						status: "error",
-						message: "채점 결과를 가져오는 데 시간이 초과되었습니다. 제출은 완료되었을 수 있으니 제출 목록에서 확인해주세요.",
-						resultInfo: { status: "error", message: "채점 시간 초과", color: "#dc3545" },
+						message:
+							"채점 결과를 가져오는 데 시간이 초과되었습니다. 제출은 완료되었을 수 있으니 제출 목록에서 확인해주세요.",
+						resultInfo: {
+							status: "error",
+							message: "채점 시간 초과",
+							color: "#dc3545",
+						},
 						submissionDbId,
 						submittedAt,
 						language: submissionLanguage,
@@ -785,11 +861,17 @@ export function useCodingQuizSolve() {
 					}
 				} catch (error: unknown) {
 					const message =
-						error instanceof Error ? error.message : "결과 조회에 실패했습니다.";
+						error instanceof Error
+							? error.message
+							: "결과 조회에 실패했습니다.";
 					setSubmissionResult({
 						status: "error",
 						message,
-						resultInfo: { status: "error", message: "결과 조회 실패", color: "#dc3545" },
+						resultInfo: {
+							status: "error",
+							message: "결과 조회 실패",
+							color: "#dc3545",
+						},
 						submissionDbId,
 						submittedAt,
 						language: submissionLanguage,
@@ -801,7 +883,14 @@ export function useCodingQuizSolve() {
 
 			pollingTimerRef.current = setTimeout(poll, POLL_INTERVAL_MS);
 		},
-		[code, language, sectionId, selectedProblemId, isSubmitBlocked, quizInfo.status],
+		[
+			code,
+			language,
+			sectionId,
+			selectedProblemId,
+			isSubmitBlocked,
+			quizInfo.status,
+		],
 	);
 
 	const handleSubmit = useCallback(async () => {
@@ -858,7 +947,11 @@ export function useCodingQuizSolve() {
 			// 채점 중 상태 표시
 			setSubmissionResult({
 				status: "judging",
-				resultInfo: { status: "judging", message: "채점 중...", color: "#6c757d" },
+				resultInfo: {
+					status: "judging",
+					message: "채점 중...",
+					color: "#6c757d",
+				},
 				submittedAt,
 				language: submittedLanguage,
 				code,
@@ -866,7 +959,8 @@ export function useCodingQuizSolve() {
 			});
 
 			// Step 2: SSE 연결 → testcase/total/complete/ce/error 이벤트 처리
-			const baseURL = process.env.REACT_APP_API_URL || "https://hcl.walab.info/api";
+			const baseURL =
+				process.env.REACT_APP_API_URL || "https://hcl.walab.info/api";
 			const token = tokenManager.getAccessToken();
 
 			await fetchEventSource(
@@ -885,7 +979,6 @@ export function useCodingQuizSolve() {
 
 							if (event.event === "total") {
 								setTotalTestcaseCount(data.count);
-
 							} else if (event.event === "testcase") {
 								setTestcaseResults((prev) => [
 									...(prev ?? []),
@@ -905,7 +998,6 @@ export function useCodingQuizSolve() {
 										output_diff: data.outputDiff,
 									},
 								];
-
 							} else if (event.event === "complete") {
 								const result: string = data.result;
 								const resultInfo = resultMapping[result] ?? {
@@ -925,7 +1017,6 @@ export function useCodingQuizSolve() {
 								});
 								setIsSubmitting(false);
 								abortController.abort();
-
 							} else if (event.event === "ce") {
 								const resultInfo = resultMapping["CE"] ?? {
 									status: "error",
@@ -943,12 +1034,15 @@ export function useCodingQuizSolve() {
 								});
 								setIsSubmitting(false);
 								abortController.abort();
-
 							} else if (event.event === "error") {
 								setSubmissionResult({
 									status: "error",
 									message: data.message,
-									resultInfo: { status: "error", message: "테스트 실패", color: "#dc3545" },
+									resultInfo: {
+										status: "error",
+										message: "테스트 실패",
+										color: "#dc3545",
+									},
 									type: "output",
 								});
 								setIsSubmitting(false);
@@ -971,12 +1065,23 @@ export function useCodingQuizSolve() {
 			setSubmissionResult({
 				status: "error",
 				message,
-				resultInfo: { status: "error", message: "테스트 실패", color: "#dc3545" },
+				resultInfo: {
+					status: "error",
+					message: "테스트 실패",
+					color: "#dc3545",
+				},
 				type: "output",
 			});
 			setIsSubmitting(false);
 		}
-	}, [code, language, sectionId, selectedProblemId, isSubmitBlocked, quizInfo.status]);
+	}, [
+		code,
+		language,
+		sectionId,
+		selectedProblemId,
+		isSubmitBlocked,
+		quizInfo.status,
+	]);
 
 	const handleHorizontalDragEnd = useCallback((sizes: number[]) => {
 		setHorizontalSizes(sizes);
@@ -995,7 +1100,8 @@ export function useCodingQuizSolve() {
 		currentProblem.description ||
 		`# ${currentProblem.title}\n\n## 문제 설명\n이 문제는 ${currentProblem.title}에 대한 설명입니다.\n\n## 제한사항\n- 문제에 대한 제한사항을 확인하세요.\n\n## 입출력 예시\n\`\`\`\n입력: 예시 입력\n출력: 예시 출력\n\`\`\``;
 
-	const hasUnsavedChanges = code !== lastSavedCodeRef.current && code !== getDefaultCode(language);
+	const hasUnsavedChanges =
+		code !== lastSavedCodeRef.current && code !== getDefaultCode(language);
 
 	return {
 		sectionId,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #214 

## 📝작업 내용
## 개요
튜터 관리 화면에서 수업을 선택한 뒤 **강의로 돌아가기** 클릭 시, 해당 분반 강의 대시보드로 이동하도록 경로를 수정했습니다.

## 배경
- 기존: `강의로 돌아가기`가 항상 `/dashboard`로 연결됨
- 기대: 수업 선택 시 `/sections/{sectionId}/dashboard` (예: `/sections/65/dashboard`)

## 변경 사항
- `Handongjudge_FE/src/layouts/TutorLayout/index.tsx`
  - `mainMenuItems` 내 **강의로 돌아가기** 항목 `path`:
    - `currentSection` 있음 → `/sections/${currentSection.sectionId}/dashboard`
    - 없음 → `/dashboard` (기존과 동일)
  - `useMemo` 의존성: `[currentSection]` 추가로 수업 변경 시 링크 갱신

## 테스트 시나리오
- [ ] `/tutor` 접속 후 수업 선택 → 사이드바 **강의로 돌아가기** 클릭 → `/sections/{선택한 sectionId}/dashboard` 로 이동하는지 확인
- [ ] 수업 미선택(또는 선택 해제) 상태에서 **강의로 돌아가기** → `/dashboard` 로 이동하는지 확인

---

## (참고) 관련 이슈/작업 — 과제 풀이「문제 선택」제출 상태

### 문제
과제 상세 문제 풀이 URL에서 제출/저장 후에도 **문제 선택** 모달에 **미제출**만 표시됨.

### 원인
`ProblemSelectModal`은 `problemStatusById`로 배지를 그리는데, 과제 풀이(`ProblemSolveView`)에서는 해당 prop을 넘기지 않아 기본값 `{}`로 동작함.

### 변경 요약
- `useProblemSolve`: `getUserSubmissionStatus`로 상태 조회, `problemStatusById` 상태 및 제출/저장/모달 오픈 시 갱신
- `ProblemSolveView` / `ProblemSolvePage`: `problemStatusById` 전달

### 관련 파일
- `src/pages/AssignmentPage/ProblemSolvePage/hooks/useProblemSolve.ts`
- `src/pages/AssignmentPage/ProblemSolvePage/components/ProblemSolveView.tsx`
- `src/pages/AssignmentPage/ProblemSolvePage/index.tsx`