### PR TITLE
feat: 문제 수정 화면 설명 에디터 항상 활성화 및 미리보기 영역 확장

### DIFF
--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditDescriptionSection.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditDescriptionSection.tsx
@@ -1,6 +1,5 @@
 import type React from "react";
 import type { RefObject } from "react";
-import ReactMarkdown from "react-markdown";
 import ProblemPreview from "../ProblemPreview";
 import * as S from "../styles";
 import type { ProblemEditHookReturn } from "../hooks/useProblemEdit";
@@ -41,238 +40,208 @@ const ProblemEditDescriptionSection: React.FC<
 			문제 설명 {enableFullEdit ? "*" : ""}
 		</S.Label>
 
-		{/* 읽기 전용 모드: 마크다운 렌더링 */}
-		{!enableFullEdit && (
-			<S.DescriptionEditor>
-				<S.EditorWrapper
-					id="problem-edit-description"
-					style={{ background: "#f5f5f5" }}
-				>
-					<div
-						style={{
-							padding: "12px",
-							minHeight: "300px",
-							overflow: "auto",
-						}}
-					>
-						<ReactMarkdown>
-							{formData.description || formData.descriptionText || "(문제 설명 없음)"}
-						</ReactMarkdown>
-					</div>
-				</S.EditorWrapper>
-				<S.Preview>
-					<S.PreviewHeader>미리보기</S.PreviewHeader>
-					<S.PreviewContent>
-						<ProblemPreview {...getFullPreviewProps()} />
-					</S.PreviewContent>
-				</S.Preview>
-			</S.DescriptionEditor>
-		)}
-
-		{/* 편집 모드(문제 변환 후): 마크다운 에디터 + 문제 설명만/전체 토글 */}
-		{enableFullEdit && (
-			<S.DescriptionEditor>
-				<S.EditorWrapper>
-					<S.EditorToolbar>
-				<S.Select
-					onChange={(e) => {
-						const v = e.target.value;
-						if (v) {
-							insertMarkdownHeading(v);
-							e.target.value = "";
-						}
-					}}
-					title="제목 스타일 (# 삽입)"
-				>
-					<option value="">제목 스타일</option>
-					<option value="h1">제목 1 (#)</option>
-					<option value="h2">제목 2 (##)</option>
-					<option value="h3">제목 3 (###)</option>
-					<option value="h4">제목 4 (####)</option>
-				</S.Select>
-				<S.Select
-					onChange={(e) => {
-						const size = e.target.value;
-						if (!size) return;
-						const el = descriptionRef.current;
-						if (!el) { e.target.value = ""; return; }
-						el.focus();
-						const openTag = `<span style="font-size: ${size}">`;
-						const closeTag = `</span>`;
-						const sel = window.getSelection();
-						if (sel && !sel.isCollapsed && sel.rangeCount > 0) {
-							const selectedText = sel.getRangeAt(0).toString();
-							document.execCommand("insertText", false, `${openTag}${selectedText}${closeTag}`);
-						} else {
-							document.execCommand("insertText", false, `${openTag}${closeTag}`);
-						}
-						const plain = el.innerText || el.textContent || "";
-						setFormData((prev) => ({ ...prev, description: plain, descriptionText: plain }));
+		{/* 설명 에디터: 항상 편집 가능 */}
+		<S.DescriptionEditor>
+			<S.EditorWrapper>
+				<S.EditorToolbar>
+			<S.Select
+				onChange={(e) => {
+					const v = e.target.value;
+					if (v) {
+						insertMarkdownHeading(v);
 						e.target.value = "";
-					}}
-					title="글자 크기"
-				>
-					<option value="">글자 크기</option>
-					<option value="0.75em">작게 (0.75x)</option>
-					<option value="1em">기본 (1x)</option>
-					<option value="1.25em">크게 (1.25x)</option>
-					<option value="1.5em">더 크게 (1.5x)</option>
-					<option value="2em">매우 크게 (2x)</option>
-				</S.Select>
+					}
+				}}
+				title="제목 스타일 (# 삽입)"
+			>
+				<option value="">제목 스타일</option>
+				<option value="h1">제목 1 (#)</option>
+				<option value="h2">제목 2 (##)</option>
+				<option value="h3">제목 3 (###)</option>
+				<option value="h4">제목 4 (####)</option>
+			</S.Select>
+			<S.Select
+				onChange={(e) => {
+					const size = e.target.value;
+					if (!size) return;
+					const el = descriptionRef.current;
+					if (!el) { e.target.value = ""; return; }
+					el.focus();
+					const openTag = `<span style="font-size: ${size}">`;
+					const closeTag = `</span>`;
+					const sel = window.getSelection();
+					if (sel && !sel.isCollapsed && sel.rangeCount > 0) {
+						const selectedText = sel.getRangeAt(0).toString();
+						document.execCommand("insertText", false, `${openTag}${selectedText}${closeTag}`);
+					} else {
+						document.execCommand("insertText", false, `${openTag}${closeTag}`);
+					}
+					const plain = el.innerText || el.textContent || "";
+					setFormData((prev) => ({ ...prev, description: plain, descriptionText: plain }));
+					e.target.value = "";
+				}}
+				title="글자 크기"
+			>
+				<option value="">글자 크기</option>
+				<option value="0.75em">작게 (0.75x)</option>
+				<option value="1em">기본 (1x)</option>
+				<option value="1.25em">크게 (1.25x)</option>
+				<option value="1.5em">더 크게 (1.5x)</option>
+				<option value="2em">매우 크게 (2x)</option>
+			</S.Select>
+				<S.ToolbarDivider />
+					<button
+						type="button"
+						onClick={() => wrapWithMarkdown("**")}
+						title="Bold (**텍스트**)"
+					>
+						<strong>B</strong>
+					</button>
+					<button
+						type="button"
+						onClick={() => wrapWithMarkdown("*")}
+						title="Italic (*텍스트*)"
+					>
+						<em>I</em>
+					</button>
+					<button
+						type="button"
+						onClick={() => wrapWithMarkdown("`")}
+						title="인라인 코드 (`코드`)"
+					>
+						{"</>"}
+					</button>
 					<S.ToolbarDivider />
-						<button
-							type="button"
-							onClick={() => wrapWithMarkdown("**")}
-							title="Bold (**텍스트**)"
-						>
-							<strong>B</strong>
-						</button>
-						<button
-							type="button"
-							onClick={() => wrapWithMarkdown("*")}
-							title="Italic (*텍스트*)"
-						>
-							<em>I</em>
-						</button>
-						<button
-							type="button"
-							onClick={() => wrapWithMarkdown("`")}
-							title="인라인 코드 (`코드`)"
-						>
-							{"</>"}
-						</button>
-						<S.ToolbarDivider />
-						<button
-							type="button"
-							onClick={() => insertMarkdownText("\n- ")}
-							title="글머리 기호 목록"
-						>
-							•
-						</button>
-						<button
-							type="button"
-							onClick={() => insertMarkdownText("\n1. ")}
-							title="번호 매기기 목록"
-						>
-							1.
-						</button>
-						<S.ToolbarDivider />
-						<button
-							type="button"
-							onClick={() => insertMarkdownText("\n> ")}
-							title="인용문"
-						>
-							&quot;
-						</button>
-						<button
-							type="button"
-							onClick={() => insertMarkdownText("\n```\n코드\n```\n")}
-							title="코드 블록"
-						>
-							&lt;&gt;
-						</button>
-						<button
-							type="button"
-							onClick={() => insertMarkdownText("\n---\n")}
-							title="구분선"
-						>
-							—
-						</button>
-					</S.EditorToolbar>
-					<S.TextEditor
-						ref={descriptionRef}
-						id="problem-edit-description"
-						contentEditable
-						role="textbox"
-						tabIndex={0}
-						data-placeholder="마크다운으로 문제 설명을 입력하세요 (예: # 제목, **굵게**, ```코드```)"
-						onPaste={(e) => {
+					<button
+						type="button"
+						onClick={() => insertMarkdownText("\n- ")}
+						title="글머리 기호 목록"
+					>
+						•
+					</button>
+					<button
+						type="button"
+						onClick={() => insertMarkdownText("\n1. ")}
+						title="번호 매기기 목록"
+					>
+						1.
+					</button>
+					<S.ToolbarDivider />
+					<button
+						type="button"
+						onClick={() => insertMarkdownText("\n> ")}
+						title="인용문"
+					>
+						&quot;
+					</button>
+					<button
+						type="button"
+						onClick={() => insertMarkdownText("\n```\n코드\n```\n")}
+						title="코드 블록"
+					>
+						&lt;&gt;
+					</button>
+					<button
+						type="button"
+						onClick={() => insertMarkdownText("\n---\n")}
+						title="구분선"
+					>
+						—
+					</button>
+				</S.EditorToolbar>
+				<S.TextEditor
+					ref={descriptionRef}
+					id="problem-edit-description"
+					contentEditable
+					role="textbox"
+					tabIndex={0}
+					data-placeholder="마크다운으로 문제 설명을 입력하세요 (예: # 제목, **굵게**, ```코드```)"
+					onPaste={(e) => {
+						e.preventDefault();
+						const paste = e.clipboardData?.getData("text") ?? "";
+						const selection = window.getSelection();
+						if (!selection?.rangeCount) return;
+						const range = selection.getRangeAt(0);
+						range.deleteContents();
+						range.insertNode(document.createTextNode(paste));
+						range.collapse(false);
+						selection.removeAllRanges();
+						selection.addRange(range);
+						const plain =
+							descriptionRef.current?.innerText ||
+							descriptionRef.current?.textContent ||
+							"";
+						setFormData((prev) => ({
+							...prev,
+							description: plain,
+							descriptionText: plain,
+						}));
+					}}
+					onInput={() => {
+						const plain =
+							descriptionRef.current?.innerText ||
+							descriptionRef.current?.textContent ||
+							"";
+						setFormData((prev) => ({
+							...prev,
+							description: plain,
+							descriptionText: plain,
+						}));
+					}}
+					onBlur={() => {
+						const plain =
+							descriptionRef.current?.innerText ||
+							descriptionRef.current?.textContent ||
+							"";
+						setFormData((prev) => ({
+							...prev,
+							description: plain,
+							descriptionText: plain,
+						}));
+					}}
+					onKeyDown={(e) => {
+						if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
 							e.preventDefault();
-							const paste = e.clipboardData?.getData("text") ?? "";
-							const selection = window.getSelection();
-							if (!selection?.rangeCount) return;
-							const range = selection.getRangeAt(0);
-							range.deleteContents();
-							range.insertNode(document.createTextNode(paste));
-							range.collapse(false);
-							selection.removeAllRanges();
-							selection.addRange(range);
-							const plain =
-								descriptionRef.current?.innerText ||
-								descriptionRef.current?.textContent ||
-								"";
-							setFormData((prev) => ({
-								...prev,
-								description: plain,
-								descriptionText: plain,
-							}));
-						}}
-						onInput={() => {
-							const plain =
-								descriptionRef.current?.innerText ||
-								descriptionRef.current?.textContent ||
-								"";
-							setFormData((prev) => ({
-								...prev,
-								description: plain,
-								descriptionText: plain,
-							}));
-						}}
-						onBlur={() => {
-							const plain =
-								descriptionRef.current?.innerText ||
-								descriptionRef.current?.textContent ||
-								"";
-							setFormData((prev) => ({
-								...prev,
-								description: plain,
-								descriptionText: plain,
-							}));
-						}}
-						onKeyDown={(e) => {
-							if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
-								e.preventDefault();
-								document.execCommand("undo", false);
-							}
-							if ((e.ctrlKey || e.metaKey) && (e.key === "y" || (e.key === "z" && e.shiftKey))) {
-								e.preventDefault();
-								document.execCommand("redo", false);
-							}
-						}}
-						suppressContentEditableWarning
+							document.execCommand("undo", false);
+						}
+						if ((e.ctrlKey || e.metaKey) && (e.key === "y" || (e.key === "z" && e.shiftKey))) {
+							e.preventDefault();
+							document.execCommand("redo", false);
+						}
+					}}
+					suppressContentEditableWarning
+				/>
+			</S.EditorWrapper>
+			<S.Preview>
+				<S.PreviewHeader>
+					<span>미리보기</span>
+					<S.PreviewModeToggle>
+						<S.PreviewModeButton
+							type="button"
+							$active={previewMode === "descriptionOnly"}
+							onClick={() => setPreviewMode("descriptionOnly")}
+						>
+							문제 설명만
+						</S.PreviewModeButton>
+						<S.PreviewModeButton
+							type="button"
+							$active={previewMode === "full"}
+							onClick={() => setPreviewMode("full")}
+						>
+							전체
+						</S.PreviewModeButton>
+					</S.PreviewModeToggle>
+				</S.PreviewHeader>
+				<S.PreviewContent>
+					<ProblemPreview
+						{...(previewMode === "descriptionOnly"
+							? getDescriptionOnlyForPreview()
+							: getFullPreviewProps())}
+						descriptionOnly={previewMode === "descriptionOnly"}
 					/>
-				</S.EditorWrapper>
-				<S.Preview>
-					<S.PreviewHeader>
-						<span>미리보기</span>
-						<S.PreviewModeToggle>
-							<S.PreviewModeButton
-								type="button"
-								$active={previewMode === "descriptionOnly"}
-								onClick={() => setPreviewMode("descriptionOnly")}
-							>
-								문제 설명만
-							</S.PreviewModeButton>
-							<S.PreviewModeButton
-								type="button"
-								$active={previewMode === "full"}
-								onClick={() => setPreviewMode("full")}
-							>
-								전체
-							</S.PreviewModeButton>
-						</S.PreviewModeToggle>
-					</S.PreviewHeader>
-					<S.PreviewContent>
-						<ProblemPreview
-							{...(previewMode === "descriptionOnly"
-								? getDescriptionOnlyForPreview()
-								: getFullPreviewProps())}
-							descriptionOnly={previewMode === "descriptionOnly"}
-						/>
-					</S.PreviewContent>
-				</S.Preview>
-			</S.DescriptionEditor>
-		)}
+				</S.PreviewContent>
+			</S.Preview>
+		</S.DescriptionEditor>
 	</S.DescriptionSection>
 );
 

--- a/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
+++ b/src/pages/TutorPage/Problems/ProblemEdit/components/ProblemEditView.tsx
@@ -93,19 +93,19 @@ export default function ProblemEditView(d: ProblemEditHookReturn) {
 								handleZipFileChange={d.handleZipFileChange}
 							/>
 
-						<ProblemEditDescriptionSection
-							descriptionRef={d.descriptionRef}
-							formData={d.formData}
-							setFormData={d.setFormData}
-							enableFullEdit={d.enableFullEdit}
-							previewMode={d.previewMode}
-							setPreviewMode={d.setPreviewMode}
-							getDescriptionOnlyForPreview={d.getDescriptionOnlyForPreview}
-							getFullPreviewProps={d.getFullPreviewProps}
-							insertMarkdownText={d.insertMarkdownText}
-							wrapWithMarkdown={d.wrapWithMarkdown}
-							insertMarkdownHeading={d.insertMarkdownHeading}
-						/>
+					<ProblemEditDescriptionSection
+						descriptionRef={d.descriptionRef}
+						formData={d.formData}
+						setFormData={d.setFormData}
+						enableFullEdit={d.enableFullEdit}
+						previewMode={d.previewMode}
+						setPreviewMode={d.setPreviewMode}
+						getDescriptionOnlyForPreview={d.getDescriptionOnlyForPreview}
+						getFullPreviewProps={d.getFullPreviewProps}
+						insertMarkdownText={d.insertMarkdownText}
+						wrapWithMarkdown={d.wrapWithMarkdown}
+						insertMarkdownHeading={d.insertMarkdownHeading}
+					/>
 
 							<ProblemEditInputOutputSection
 								formData={d.formData}

--- a/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
@@ -629,57 +629,58 @@ export function useProblemEdit() {
 			e.preventDefault();
 			if (!problemId) return;
 
-			const strictNow = Boolean(formData.strictWhitespaceGrading);
-			const strictChanged = strictNow !== originalStrictWhitespaceRef.current;
-			const useFullPayload = enableFullEdit || strictChanged;
+		const strictNow = Boolean(formData.strictWhitespaceGrading);
+		const strictChanged = strictNow !== originalStrictWhitespaceRef.current;
+		const useFullPayload = enableFullEdit || strictChanged;
 
-			if (useFullPayload) {
-				const hasDescription =
-					(formData.description?.trim() || formData.descriptionText?.trim()) ?? "";
-				if (!hasDescription) {
-					alert("문제 설명을 입력해 주세요.");
-					return;
-				}
-				const hasTestcases =
-					parsedTestCases.some(
-						(tc) => tc.input?.trim() && tc.output?.trim(),
-					) ||
-					formData.testcases.some(
-						(tc) => tc.input?.trim() && tc.output?.trim(),
-					);
-				if (!hasTestcases) {
-					alert("테스트케이스가 최소 1개 이상 필요합니다. (입력/출력 쌍 모두 있어야 합니다)");
-					return;
-				}
-				const incomplete = validateTestCases();
-				if (incomplete.length > 0) {
-					const message = incomplete
-						.map((tc) => `- ${tc.name}: ${tc.missing} 파일이 없습니다`)
-						.join("\n");
-					alert(
-						`다음 테스트케이스에 입력/출력이 비어 있습니다:\n\n${message}\n\n모든 테스트케이스를 완성한 후 제출해 주세요.`,
-					);
-					return;
-				}
+		if (useFullPayload) {
+			const hasDescription =
+				(formData.description?.trim() || formData.descriptionText?.trim()) ?? "";
+			if (!hasDescription) {
+				alert("문제 설명을 입력해 주세요.");
+				return;
 			}
+			const hasTestcases =
+				parsedTestCases.some(
+					(tc) => tc.input?.trim() && tc.output?.trim(),
+				) ||
+				formData.testcases.some(
+					(tc) => tc.input?.trim() && tc.output?.trim(),
+				);
+			if (!hasTestcases) {
+				alert("테스트케이스가 최소 1개 이상 필요합니다. (입력/출력 쌍 모두 있어야 합니다)");
+				return;
+			}
+			const incomplete = validateTestCases();
+			if (incomplete.length > 0) {
+				const message = incomplete
+					.map((tc) => `- ${tc.name}: ${tc.missing} 파일이 없습니다`)
+					.join("\n");
+				alert(
+					`다음 테스트케이스에 입력/출력이 비어 있습니다:\n\n${message}\n\n모든 테스트케이스를 완성한 후 제출해 주세요.`,
+				);
+				return;
+			}
+		}
 
-			setSubmitting(true);
-			setError(null);
-			try {
-				const submitFormData = new FormData();
-				submitFormData.append("title", formData.title);
-				submitFormData.append("tags", JSON.stringify(formData.tags));
-				submitFormData.append("difficulty", formData.difficulty?.trim() || "1");
-				submitFormData.append(
-					"strictWhitespaceGrading",
-					formData.strictWhitespaceGrading ? "true" : "false",
-				);
-				submitFormData.append(
-					"metadataUpdated",
-					useFullPayload ? "false" : "true",
-				);
-				if (useFullPayload) {
-					submitFormData.append("description", getFullDescriptionForBackend());
+		setSubmitting(true);
+		setError(null);
+		try {
+			const submitFormData = new FormData();
+			submitFormData.append("title", formData.title);
+			submitFormData.append("tags", JSON.stringify(formData.tags));
+			submitFormData.append("difficulty", formData.difficulty?.trim() || "1");
+			submitFormData.append(
+				"strictWhitespaceGrading",
+				formData.strictWhitespaceGrading ? "true" : "false",
+			);
+			submitFormData.append(
+				"metadataUpdated",
+				useFullPayload ? "false" : "true",
+			);
+			// description은 항상 포함 (DOMjudge 재업로드 없이 DB description 갱신)
+			submitFormData.append("description", getFullDescriptionForBackend());
+			if (useFullPayload) {
 					submitFormData.append("inputFormat", formData.inputFormat);
 					submitFormData.append("outputFormat", formData.outputFormat);
 					const timeLimit = formData.timeLimit || originalTimeLimit || "1";

--- a/src/pages/TutorPage/Problems/ProblemEdit/styles.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/styles.ts
@@ -132,17 +132,19 @@ export const DescriptionSection = styled.div`
 
 export const DescriptionEditor = styled.div`
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  grid-template-columns: 1fr 1.8fr;
+  gap: 0;
   border: 2px solid #e2e8f0;
   border-radius: 8px;
   overflow: hidden;
+  min-height: 500px;
 `;
 
 export const EditorWrapper = styled.div`
   display: flex;
   flex-direction: column;
   background: #f8fafc;
+  border-right: 1px solid #e2e8f0;
 `;
 
 export const EditorToolbar = styled.div`
@@ -250,6 +252,7 @@ export const Preview = styled.div`
   display: flex;
   flex-direction: column;
   background: white;
+  overflow-y: auto;
 `;
 
 export const PreviewHeader = styled.div`


### PR DESCRIPTION
- 문제 설명 에디터를 별도 버튼 클릭 없이 항상 편집 가능하도록 변경 (기존 읽기 전용 ReactMarkdown 뷰 및 enableDescriptionEdit 토글 제거)
- handleSubmit에서 description을 항상 payload에 포함 (metadataUpdated=true 유지 → DOMjudge 재업로드 없이 설명만 저장)
- DescriptionEditor 미리보기 비율 1:1 → 1:1.8로 확장
- min-height 500px 추가, 에디터/미리보기 경계선 추가

