### PR TITLE
fix/issue-219/edit에서 <> 빈값처리 없앰

### DIFF
--- a/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
+++ b/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts
@@ -30,6 +30,17 @@ export type ProblemEditLocationState = {
 	assignmentId?: number;
 } | null;
 
+/**
+ * contenteditable에 innerHTML을 넣을지 결정할 때 사용.
+ * `<S, T>`, `<>` 같은 리터럴은 false — 실제 HTML 태그(br, p, strong 등)일 때만 true.
+ */
+function looksLikeImportedHtml(s: string): boolean {
+	if (!s || !s.includes("<")) return false;
+	return /<\s*(?:p|div|br\s*\/?|span|strong|em|b|i|u|h[1-6]|ul|ol|li|table|thead|tbody|tr|td|th|pre|code|blockquote|a\b)/i.test(
+		s,
+	);
+}
+
 export function useProblemEdit() {
 	const navigate = useNavigate();
 	const location = useLocation();
@@ -91,12 +102,10 @@ export function useProblemEdit() {
 			}
 			const rawDescription = parsedData?.description ?? problem?.description ?? "";
 			const descriptionText = (rawDescription || "")
-				.replace(/<[^>]*>/g, "")
 				.replace(/\r\n/g, "\n")
 				.replace(/\r/g, "\n")
 				.trim();
 			const parsed = parseDescriptionSections(descriptionText);
-			const description = parsed.mainDescription;
 			const mainDescriptionText = parsed.mainDescription;
 			let timeLimit = "";
 			if (parsedData?.timeLimit != null) {
@@ -164,8 +173,7 @@ export function useProblemEdit() {
 			setEnableFullEdit(false);
 			setTimeout(() => {
 				if (descriptionRef.current) {
-					const isHTML = /<[^>]+>/.test(mainDescriptionText);
-					if (isHTML) {
+					if (looksLikeImportedHtml(mainDescriptionText)) {
 						descriptionRef.current.innerHTML = mainDescriptionText;
 					} else {
 						descriptionRef.current.textContent = mainDescriptionText;
@@ -192,8 +200,7 @@ export function useProblemEdit() {
 			isInitialLoad &&
 			!loading
 		) {
-			const isHTML = /<[^>]+>/.test(formData.description);
-			if (isHTML) {
+			if (looksLikeImportedHtml(formData.description)) {
 				descriptionRef.current.innerHTML = formData.description;
 			} else {
 				descriptionRef.current.textContent =
@@ -205,8 +212,7 @@ export function useProblemEdit() {
 
 	useEffect(() => {
 		if (enableFullEdit && descriptionRef.current && formData.description) {
-			const isHTML = /<[^>]+>/.test(formData.description);
-			if (isHTML) {
+			if (looksLikeImportedHtml(formData.description)) {
 				descriptionRef.current.innerHTML = formData.description;
 			} else {
 				descriptionRef.current.textContent =
@@ -258,7 +264,7 @@ export function useProblemEdit() {
 							.replace(/\n/g, "<br>")
 							.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>")
 							.replace(/\*(.*?)\*/g, "<em>$1</em>");
-						const descText = parsedData.description.replace(/<[^>]*>/g, "");
+						const descText = parsedData.description;
 						setFormData((prev) => ({
 							...prev,
 							description: htmlDesc,


### PR DESCRIPTION
## #️⃣연관된 이슈

> #219 

## 📝작업 내용
### 요약
- `/tutor/problems` 목록·문제 보기 모달에서는 문제 설명의 `<>` 표기가 정상 표시됨.
- `/tutor/problems/{id}/edit` 에서는 동일 데이터임에도 `<...>` 구간이 보이지 않거나 비어 보임.

### 원인
- 문제 편집 훅 `useProblemEdit.ts`의 `fetchProblem`에서, 섹션 분리(`parseDescriptionSections`) 전에 **무조건** 다음 전처리가 적용됨.
  - `.replace(/<[^>]*>/g, "")` → `<`부터 다음 `>`까지를 한 덩어리로 삭제.
- 수식·집합·입출력 표기 등 **HTML이 아닌 리터럴 `<S, T>`, `<>`** 도 동일 규칙으로 제거됨.
- ZIP 재파싱 경로에서도 `descText` 생성 시 같은 `replace` 사용.

목록/모달은 `description`을 그대로 렌더하지만, 편집만 위 전처리가 있어 **표시 불일치**가 발생.

### 수정 내용
- 로드·ZIP 파싱 시 **위 태그 제거 `replace` 제거** (줄바꿈 정규화만 유지).
- `contenteditable`에 `innerHTML`을 쓰는 조건을 `/<[^>]+>/` 단순 매칭 대신, **`br`, `p`, `strong`, `em` 등 실제 HTML로 쓰인 태그가 있을 때만** `innerHTML`을 쓰도록 `looksLikeImportedHtml()` 도입. 그 외는 `textContent`로 넣어 `<>` 리터럴이 브라우저 파서에 의해 깨지지 않도록 함.

### 변경 파일
- `Handongjudge_FE/src/pages/TutorPage/Problems/ProblemEdit/hooks/useProblemEdit.ts`

### 테스트 방법
1. 설명에 `<S, T>` 또는 `<>` 가 포함된 문제를 DB/목록에서 확인.
2. 동일 문제를 `/tutor/problems/{id}/edit` 에서 연 뒤 설명 필드에 동일하게 보이는지 확인.
3. (선택) ZIP으로 설명을 다시 불러올 때도 괄호 표기가 유지되는지 확인.

### 참고
- 보안·XSS와 별개로, 기존 `replace`는 “HTML 태그 제거” 의도로 보이나 리터럴 `<>` 까지 제거하는 과도한 동작이었음.